### PR TITLE
Renamed nuget package to Motiv

### DIFF
--- a/Karlssberg.Motiv/Karlssberg.Motiv.csproj
+++ b/Karlssberg.Motiv/Karlssberg.Motiv.csproj
@@ -7,7 +7,7 @@
         <Authors>Daniel Karlsson</Authors>
         <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageId>Karlssberg.Motiv</PackageId>
+        <PackageId>Motiv</PackageId>
         <Title>Motiv</Title>
         <Description>Motiv lets you explain to users (and other stakeholders including devs) what is going on with your boolean logic.  It can also be used to model meaningful domain logic (like with DDD), or even as a way to construct stateful objects based on conditional logic </Description>
         <Copyright>Copyright (c) 2024 karlssberg</Copyright>


### PR DESCRIPTION
To keep the naming consistent and professional looking, the github username is being dropped from the nuget package id.