### PR TITLE
prevent negation ambiguity with the ! symbol

### DIFF
--- a/Motiv.Tests/AndAlsoSpecTests.cs
+++ b/Motiv.Tests/AndAlsoSpecTests.cs
@@ -317,9 +317,9 @@ public class AndAlsoSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left")]
-    [InlineData(false, true, "!left")]
-    [InlineData(true, false, "!right")]
+    [InlineData(false, false, "¬left")]
+    [InlineData(false, true, "¬left")]
+    [InlineData(true, false, "¬right")]
     [InlineData(true, true, "left", "right")]
     public void Should_perform_AndAlso_on_specs_with_different_metadata_and_preserve_assertions(
         bool leftValue,
@@ -349,9 +349,9 @@ public class AndAlsoSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left")]
-    [InlineData(false, true, "!left")]
-    [InlineData(true, false, "!right")]
+    [InlineData(false, false, "¬left")]
+    [InlineData(false, true, "¬left")]
+    [InlineData(true, false, "¬right")]
     [InlineData(true, true, "left", "right")]
     public void Should_perform_AndAlso_on_specs_with_different_metadata_and_preserve_metadata(
         bool leftValue,
@@ -463,17 +463,17 @@ public class AndAlsoSpecTests
     [InlineData(true, false,
         """
         NAND
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         NAND
-            !left
+            ¬left
         """)]
     [InlineData(false, false,
         """
         NAND
-            !left
+            ¬left
         """)]
     public void Should_justify_a_nand_creation(bool leftBool, bool rightBool, string expected)
     {
@@ -497,17 +497,17 @@ public class AndAlsoSpecTests
     [InlineData(true, false,
         """
         AND
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         AND
-            !left
+            ¬left
         """)]
     [InlineData(false, false,
         """
         AND
-            !left
+            ¬left
         """)]
     public void Should_justify_a_nand_negation(bool leftBool, bool rightBool, string expected)
     {
@@ -531,17 +531,17 @@ public class AndAlsoSpecTests
     [InlineData(true, false,
         """
         NAND
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         NAND
-            !left
+            ¬left
         """)]
     [InlineData(false, false,
         """
         NAND
-            !left
+            ¬left
         """)]
     public void Should_justify_a_nand_double_negation(bool leftBool, bool rightBool, string expected)
     {

--- a/Motiv.Tests/AndSpecTests.cs
+++ b/Motiv.Tests/AndSpecTests.cs
@@ -72,9 +72,9 @@ public class AndSpecTests
 
     [Theory]
     [InlineAutoData(true, true, "left & right")]
-    [InlineAutoData(true, false, "!right")]
-    [InlineAutoData(false, true, "!left")]
-    [InlineAutoData(false, false, "!left & !right")]
+    [InlineAutoData(true, false, "¬right")]
+    [InlineAutoData(false, true, "¬left")]
+    [InlineAutoData(false, false, "¬left & ¬right")]
     public void Should_serialize_the_result_of_the_and_operation(
         bool leftResult,
         bool rightResult,
@@ -362,7 +362,7 @@ public class AndSpecTests
         var result = (isActive & isUsa).Reason;
 
         // Assert
-        result.Should().Be("subscription has started & subscription has not ended & the location is in the USA");
+        result.Should().Be("subscription has started & !subscription has not ended & the location is in the USA");
     }
 
     [Theory]
@@ -467,9 +467,9 @@ public class AndSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left", "!right")]
-    [InlineData(false, true, "!left")]
-    [InlineData(true, false, "!right")]
+    [InlineData(false, false, "¬left", "¬right")]
+    [InlineData(false, true, "¬left")]
+    [InlineData(true, false, "¬right")]
     [InlineData(true, true, "left", "right")]
     public void Should_perform_And_on_specs_with_different_metadata_and_preserve_assertions(
         bool leftValue,
@@ -498,9 +498,9 @@ public class AndSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left", "!right")]
-    [InlineData(false, true, "!left")]
-    [InlineData(true, false, "!right")]
+    [InlineData(false, false, "¬left", "¬right")]
+    [InlineData(false, true, "¬left")]
+    [InlineData(true, false, "¬right")]
     [InlineData(true, true, "left", "right")]
     public void Should_perform_And_on_specs_with_different_metadata_and_preserve_metadata(
         bool leftValue,
@@ -612,18 +612,18 @@ public class AndSpecTests
     [InlineData(true, false,
         """
         NAND
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         NAND
-            !left
+            ¬left
         """)]
     [InlineData(false, false,
         """
         NAND
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nand_creation(bool leftBool, bool rightBool, string expected)
     {
@@ -647,18 +647,18 @@ public class AndSpecTests
     [InlineData(true, false,
         """
         AND
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         AND
-            !left
+            ¬left
         """)]
     [InlineData(false, false,
         """
         AND
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nand_negation(bool leftBool, bool rightBool, string expected)
     {
@@ -682,18 +682,18 @@ public class AndSpecTests
     [InlineData(true, false,
         """
         NAND
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         NAND
-            !left
+            ¬left
         """)]
     [InlineData(false, false,
         """
         NAND
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nand_double_negation(bool leftBool, bool rightBool, string expected)
     {

--- a/Motiv.Tests/AsAllSatisfiedSpecTests.cs
+++ b/Motiv.Tests/AsAllSatisfiedSpecTests.cs
@@ -40,36 +40,36 @@ public class AsAllSatisfiedSpecTests
 
     [Theory]
     [InlineAutoData(false, false, false, """
-                                            !all are true
+                                            ¬all are true
                                                 false
                                                 false
                                                 false
                                             """)]
     [InlineAutoData(false, false, true, """
-                                            !all are true
+                                            ¬all are true
                                                 false
                                                 false
                                             """)]
     [InlineAutoData(false, true, false, """
-                                            !all are true
+                                            ¬all are true
                                                 false
                                                 false
                                             """)]
     [InlineAutoData(false, true, true, """
-                                            !all are true
+                                            ¬all are true
                                                 false
                                             """)]
     [InlineAutoData(true, false, false, """
-                                            !all are true
+                                            ¬all are true
                                                 false
                                                 false
                                             """)]
     [InlineAutoData(true, false, true, """
-                                            !all are true
+                                            ¬all are true
                                                 false
                                             """)]
     [InlineAutoData(true, true, false, """
-                                            !all are true
+                                            ¬all are true
                                                 false
                                             """)]
     [InlineAutoData(true, true, true, """
@@ -97,7 +97,7 @@ public class AsAllSatisfiedSpecTests
             .WhenTrueYield(evaluation => evaluation.Metadata)
             .WhenFalseYield(evaluation => evaluation.Metadata)
             .Create("all are true");
-        
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
@@ -109,36 +109,36 @@ public class AsAllSatisfiedSpecTests
 
     [Theory]
     [InlineAutoData(false, false, false, """
-                                        !all are true
+                                        ¬all are true
                                             false
                                             false
                                             false
                                         """)]
     [InlineAutoData(false, false, true, """
-                                        !all are true
+                                        ¬all are true
                                             false
                                             false
                                         """)]
     [InlineAutoData(false, true, false, """
-                                        !all are true
+                                        ¬all are true
                                             false
                                             false
                                         """)]
     [InlineAutoData(false, true, true, """
-                                        !all are true
+                                        ¬all are true
                                             false
                                         """)]
     [InlineAutoData(true, false, false, """
-                                        !all are true
+                                        ¬all are true
                                             false
                                             false
                                         """)]
     [InlineAutoData(true, false, true, """
-                                        !all are true
+                                        ¬all are true
                                             false
                                         """)]
     [InlineAutoData(true, true, false, """
-                                        !all are true
+                                        ¬all are true
                                             false
                                         """)]
     [InlineAutoData(true, true, true, """
@@ -172,44 +172,44 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
 
     [Theory]
     [InlineAutoData(false, false, false, """
-                                        !all are true
-                                            !is true
-                                            !is true
-                                            !is true
+                                        ¬all are true
+                                            ¬is true
+                                            ¬is true
+                                            ¬is true
                                         """)]
     [InlineAutoData(false, false, true, """
-                                        !all are true
-                                            !is true
-                                            !is true
+                                        ¬all are true
+                                            ¬is true
+                                            ¬is true
                                         """)]
     [InlineAutoData(false, true, false, """
-                                        !all are true
-                                            !is true
-                                            !is true
+                                        ¬all are true
+                                            ¬is true
+                                            ¬is true
                                         """)]
     [InlineAutoData(false, true, true, """
-                                        !all are true
-                                            !is true
+                                        ¬all are true
+                                            ¬is true
                                         """)]
     [InlineAutoData(true, false, false, """
-                                        !all are true
-                                            !is true
-                                            !is true
+                                        ¬all are true
+                                            ¬is true
+                                            ¬is true
                                         """)]
     [InlineAutoData(true, false, true, """
-                                       !all are true
-                                           !is true
+                                       ¬all are true
+                                           ¬is true
                                        """)]
     [InlineAutoData(true, true, false, """
-                                       !all are true
-                                           !is true
+                                       ¬all are true
+                                           ¬is true
                                        """)]
     [InlineAutoData(true, true, true, """
                                       all are true
@@ -241,68 +241,68 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
 
     [Theory]
     [InlineAutoData(false, false, false, """
-                                            !all are true
+                                            ¬all are true
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                             """)]
     [InlineAutoData(false, false, true, """
-                                            !all are true
+                                            ¬all are true
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                             """)]
     [InlineAutoData(false, true, false, """
-                                            !all are true
+                                            ¬all are true
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                             """)]
     [InlineAutoData(false, true, true, """
-                                            !all are true
+                                            ¬all are true
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                             """)]
     [InlineAutoData(true, false, false, """
-                                            !all are true
+                                            ¬all are true
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                             """)]
     [InlineAutoData(true, false, true, """
-                                            !all are true
+                                            ¬all are true
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                             """)]
     [InlineAutoData(true, true, false, """
-                                            !all are true
+                                            ¬all are true
                                                 AND
-                                                    !left
-                                                    !right
+                                                    ¬left
+                                                    ¬right
                                             """)]
     [InlineAutoData(true, true, true, """
                                             all are true
@@ -346,19 +346,19 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
 
     [Theory]
-    [InlineAutoData(false, false, false, "!all are true")]
-    [InlineAutoData(false, false, true, "!all are true")]
-    [InlineAutoData(false, true, false, "!all are true")]
-    [InlineAutoData(false, true, true, "!all are true")]
-    [InlineAutoData(true, false, false, "!all are true")]
-    [InlineAutoData(true, false, true, "!all are true")]
-    [InlineAutoData(true, true, false, "!all are true")]
+    [InlineAutoData(false, false, false, "¬all are true")]
+    [InlineAutoData(false, false, true, "¬all are true")]
+    [InlineAutoData(false, true, false, "¬all are true")]
+    [InlineAutoData(false, true, true, "¬all are true")]
+    [InlineAutoData(true, false, false, "¬all are true")]
+    [InlineAutoData(true, false, true, "¬all are true")]
+    [InlineAutoData(true, true, false, "¬all are true")]
     [InlineAutoData(true, true, true, "all are true")]
     public void Should_Describe_the_result_of_the_all_operation_and_show_multiple_underlying_causes(
         bool first,
@@ -390,19 +390,19 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
-    [InlineAutoData(false, false, false, "!all are true")]
-    [InlineAutoData(false, false, true, "!all are true")]
-    [InlineAutoData(false, true, false, "!all are true")]
-    [InlineAutoData(false, true, true, "!all are true")]
-    [InlineAutoData(true, false, false, "!all are true")]
-    [InlineAutoData(true, false, true, "!all are true")]
-    [InlineAutoData(true, true, false, "!all are true")]
+    [InlineAutoData(false, false, false, "¬all are true")]
+    [InlineAutoData(false, false, true, "¬all are true")]
+    [InlineAutoData(false, true, false, "¬all are true")]
+    [InlineAutoData(false, true, true, "¬all are true")]
+    [InlineAutoData(true, false, false, "¬all are true")]
+    [InlineAutoData(true, false, true, "¬all are true")]
+    [InlineAutoData(true, true, false, "¬all are true")]
     [InlineAutoData(true, true, true, "all are true")]
     public void Should_serialize_the_result_of_the_all_operation_and_show_underlying_causes(
         bool first,
@@ -434,7 +434,7 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = result.ToString();
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -461,11 +461,11 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = sut.Statement;
-        
+
         // Assert
         act.Should().Be(expectedSummary);
     }
-    
+
     [Fact]
     public void Should_provide_a_serialized_expression_tree_of_the_specification()
     {
@@ -491,12 +491,12 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = spec.Expression;
-        
+
         // Assert
         act.Should().Be(expectedFull);
     }
-    
-    [Fact]  
+
+    [Fact]
     public void Should_provide_a_statement_of_the_specification_when_metadata_is_a_string()
     {
         // Arrange
@@ -517,12 +517,12 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be(expectedSummary);
     }
-    
-    [Fact]  
+
+    [Fact]
     public void Should_provide_a_serialized_expression_tree_of_the_specification_when_metadata_is_a_string()
     {
         // Arrange
@@ -546,11 +546,11 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = spec.Expression;
-        
+
         // Assert
         act.Should().Be(expectedFull);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, false, 3)]
     [InlineAutoData(false, false, true, 2)]
@@ -570,7 +570,7 @@ public class AsAllSatisfiedSpecTests
         var underlying = Spec
             .Build((bool m) => m)
             .Create("underlying");
-        
+
         var spec = Spec
             .Build(underlying)
             .AsAllSatisfied()
@@ -580,7 +580,7 @@ public class AsAllSatisfiedSpecTests
 
         // Act
         var act = result.Description.CausalOperandCount;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -601,18 +601,18 @@ public class AsAllSatisfiedSpecTests
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .AsAllSatisfied()
             .Create("all are true");
-        
+
         // Act
         var act = spec.IsSatisfiedBy([modelA, modelB]).Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
 
     [Theory]
-    [InlineAutoData(false, false, "!all are true")]
-    [InlineAutoData(false, true, "!all are true")]
-    [InlineAutoData(true, false, "!all are true")]
+    [InlineAutoData(false, false, "¬all are true")]
+    [InlineAutoData(false, true, "¬all are true")]
+    [InlineAutoData(true, false, "¬all are true")]
     [InlineAutoData(true, true, "all are true")]
     public void Should_surface_reasons_from_underlyingResult(bool modelA, bool modelB, string expectedAssertion)
     {
@@ -625,10 +625,10 @@ public class AsAllSatisfiedSpecTests
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .AsAllSatisfied()
             .Create("all are true");
-        
+
         // Act
         var act = spec.IsSatisfiedBy([modelA, modelB]).Reason;
-        
+
         // Assert
         act.Should().Be(expectedAssertion);
     }
@@ -654,14 +654,14 @@ public class AsAllSatisfiedSpecTests
             .WhenTrue("all are true")
             .WhenFalse("not all are true")
             .Create();
-        
+
         // Act
         var act = spec.IsSatisfiedBy([modelA, modelB]).Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
 
     [Theory]
     [InlineAutoData(false, false, "not all are true")]
@@ -684,14 +684,14 @@ public class AsAllSatisfiedSpecTests
             .WhenTrue("all are true")
             .WhenFalse("not all are true")
             .Create();
-        
+
         // Act
         var act = spec.IsSatisfiedBy([modelA, modelB]).Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedAssertion]);
     }
-    
+
 
     [Theory]
     [InlineAutoData(false, false, "not all are true")]
@@ -714,14 +714,14 @@ public class AsAllSatisfiedSpecTests
             .WhenTrue("all are true")
             .WhenFalse("not all are true")
             .Create();
-        
+
         // Act
         var act = spec.IsSatisfiedBy([modelA, modelB]).Reason;
-        
+
         // Assert
         act.Should().Be(expectedAssertion);
     }
-   
+
     [Theory]
     [InlineAutoData(false, false, false)]
     [InlineAutoData(false, true, false)]
@@ -741,15 +741,15 @@ public class AsAllSatisfiedSpecTests
             .Create();
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
-    
+
+
     [Theory]
     [InlineAutoData(false, false, "not all are true")]
     [InlineAutoData(false, true, "not all are true")]
@@ -767,16 +767,16 @@ public class AsAllSatisfiedSpecTests
             .WhenTrue("all are true")
             .WhenFalse("not all are true")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([modelA, modelB]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedAssertion);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, "not all are true")]
     [InlineAutoData(false, true, "not all are true")]
@@ -796,14 +796,14 @@ public class AsAllSatisfiedSpecTests
             .Create();
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedAssertion]);
     }
-    
+
     [Theory]
     [InlineData(false, false, false)]
     [InlineData(false, true, false)]
@@ -823,14 +823,14 @@ public class AsAllSatisfiedSpecTests
             .Create("all true");
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, "not all are true")]
     [InlineData(false, true, "not all are true")]
@@ -849,14 +849,14 @@ public class AsAllSatisfiedSpecTests
             .Create("all true");
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(false, false, "not all are true")]
     [InlineData(false, true, "not all are true")]
@@ -876,10 +876,10 @@ public class AsAllSatisfiedSpecTests
             .Create("all true");
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedAssertion]);
     }

--- a/Motiv.Tests/AsAnySatisfiedSpecTests.cs
+++ b/Motiv.Tests/AsAnySatisfiedSpecTests.cs
@@ -29,74 +29,74 @@ public class AsAnySatisfiedSpecTests
             .WhenTrue(true)
             .WhenFalse(false)
             .Create("any satisfied");
-        
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Should_provide_a_high_level_statement_of_the_specification_when_metadata_is_a_string()
     {
         // Arrange
         const string expected = "high-level description";
-        
+
         var underlyingSpec = Spec
             .Build((bool m) => m)
-            .WhenTrue("boolean is true")   
+            .WhenTrue("boolean is true")
             .WhenFalse("boolean is false")
             .Create();
 
         var spec = Spec
             .Build(underlyingSpec)
-            .AsAnySatisfied()   
+            .AsAnySatisfied()
             .WhenTrue(true)
             .WhenFalse(false)
             .Create("high-level description");
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Should_serialize_a_description_of_the_specification_when_metadata_is_a_string()
     {
         // Arrange
         const string expected = "high-level description";
-        
+
         var underlyingSpec = Spec
             .Build((bool m) => m)
-            .WhenTrue("boolean is true")   
+            .WhenTrue("boolean is true")
             .WhenFalse("boolean is false")
             .Create();
 
         var spec = Spec
             .Build(underlyingSpec)
-            .AsAnySatisfied()   
+            .AsAnySatisfied()
             .WhenTrue(true)
             .WhenFalse(false)
             .Create("high-level description");
 
         // Act
         var act = spec.ToString();
-        
+
         // Assert
         act.Should().Be(expected);
     }
 
     [Theory]
     [InlineAutoData(false, false, false, """
-                                            !any satisfied
-                                                !is true
-                                                !is true
-                                                !is true
+                                            ¬any satisfied
+                                                ¬is true
+                                                ¬is true
+                                                ¬is true
                                             """)]
     [InlineAutoData(false, false, true,  """
                                             any satisfied
@@ -150,12 +150,12 @@ public class AsAnySatisfiedSpecTests
             .WhenTrue(true)
             .WhenFalse(false)
             .Create("any satisfied");
-            
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -224,7 +224,7 @@ public class AsAnySatisfiedSpecTests
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -288,16 +288,16 @@ public class AsAnySatisfiedSpecTests
             .WhenTrue(_ => "any true")
             .WhenFalse(_ => "all false")
             .Create("any true");
-        
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, false, 3)]
     [InlineAutoData(false, false, true, 1)]
@@ -317,7 +317,7 @@ public class AsAnySatisfiedSpecTests
         var underlying = Spec
             .Build((bool m) => m)
             .Create("underlying");
-        
+
         var spec = Spec
             .Build(underlying)
             .AsAnySatisfied()
@@ -327,7 +327,7 @@ public class AsAnySatisfiedSpecTests
 
         // Act
         var act = result.Description.CausalOperandCount;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -349,16 +349,16 @@ public class AsAnySatisfiedSpecTests
             .Create("any true");
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
-    [InlineAutoData(false, false, "!any true")]
+    [InlineAutoData(false, false, "¬any true")]
     [InlineAutoData(false, true, "any true")]
     [InlineAutoData(true, false, "any true")]
     [InlineAutoData(true, true, "any true")]
@@ -375,10 +375,10 @@ public class AsAnySatisfiedSpecTests
             .Create("any true");
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedAssertion);
     }
@@ -406,14 +406,14 @@ public class AsAnySatisfiedSpecTests
             .Create();
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, "none are true")]
     [InlineAutoData(false, true, "some are true")]
@@ -437,14 +437,14 @@ public class AsAnySatisfiedSpecTests
             .Create();
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedAssertion);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, "none are true")]
     [InlineAutoData(false, true, "some are true")]
@@ -468,14 +468,14 @@ public class AsAnySatisfiedSpecTests
             .Create();
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedAssertion]);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, false)]
     [InlineAutoData(false, true, true)]
@@ -495,14 +495,14 @@ public class AsAnySatisfiedSpecTests
             .Create();
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, "none are true")]
     [InlineAutoData(false, true, "some are true")]
@@ -522,14 +522,14 @@ public class AsAnySatisfiedSpecTests
             .Create();
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedAssertion);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, "none are true")]
     [InlineAutoData(false, true, "some are true")]
@@ -549,14 +549,14 @@ public class AsAnySatisfiedSpecTests
             .Create();
 
         var result = spec.IsSatisfiedBy([modelA, modelB]);
-        
+
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedAssertion]);
     }
-    
+
     [Theory]
     [InlineData(false, false, false)]
     [InlineData(false, true, true)]
@@ -574,16 +574,16 @@ public class AsAnySatisfiedSpecTests
             .WhenTrue("some are true")
             .WhenFalse("none are true")
             .Create("any true");
-        
+
         var result = spec.IsSatisfiedBy([modelA, modelB]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, "none are true")]
     [InlineData(false, true, "some are true")]
@@ -601,16 +601,16 @@ public class AsAnySatisfiedSpecTests
             .WhenTrue("some are true")
             .WhenFalse("none are true")
             .Create("any true");
-        
+
         var result = spec.IsSatisfiedBy([modelA, modelB]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(false, false, "none are true")]
     [InlineData(false, true, "some are true")]
@@ -628,12 +628,12 @@ public class AsAnySatisfiedSpecTests
             .WhenTrue("some are true")
             .WhenFalse("none are true")
             .Create("any true");
-        
+
         var result = spec.IsSatisfiedBy([modelA, modelB]);
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedReason]);
     }

--- a/Motiv.Tests/AsAtLeastNSatisfiedSpecBaseTests.cs
+++ b/Motiv.Tests/AsAtLeastNSatisfiedSpecBaseTests.cs
@@ -39,12 +39,12 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             .WhenTrue("none satisfied")
             .WhenFalse("at least one satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third, fourth]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -86,12 +86,12 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             .WhenTrue("One satisfied")
             .WhenFalse("None or more than one satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third, fourth]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -133,12 +133,12 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             .WhenTrue("At least two satisfied")
             .WhenFalse("Less than two satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third, fourth]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -180,12 +180,12 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             .WhenTrue("All satisfied")
             .WhenFalse("Not all satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third, fourth]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -249,12 +249,12 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             .WhenTrue("at least one satisfied")
             .WhenFalse("none satisfied")
             .Create();
-            
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -318,12 +318,12 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             .WhenTrue("At least one satisfied")
             .WhenFalse("None satisfied")
             .Create();
-            
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -331,9 +331,9 @@ public class AsAtLeastNSatisfiedSpecBaseTests
     [Theory]
     [InlineAutoData(false, false, false, """
                                             none satisfied
-                                                !is true
-                                                !is true
-                                                !is true
+                                                ¬is true
+                                                ¬is true
+                                                ¬is true
                                             """)]
     [InlineAutoData(false, false, true,  """
                                             at least one satisfied
@@ -387,12 +387,12 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             .WhenTrue("at least one satisfied")
             .WhenFalse("none satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -402,7 +402,7 @@ public class AsAtLeastNSatisfiedSpecBaseTests
     {
         // Arrange
         const string expected = "at least one satisfied";
-        
+
         var underlyingSpec = Spec
             .Build((bool m) => m)
             .WhenTrue(true.ToString())
@@ -418,17 +418,17 @@ public class AsAtLeastNSatisfiedSpecBaseTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Should_serialize_the_spec_using_the_ToString_method()
     {
         // Arrange
         const string expected = "at least one satisfied";
-        
+
         var underlyingSpec = Spec
             .Build((bool m) => m)
             .WhenTrue(true.ToString())
@@ -444,11 +444,11 @@ public class AsAtLeastNSatisfiedSpecBaseTests
 
         // Act
         var act = spec.ToString();
-        
-        // Assert    
+
+        // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, false, 3)]
     [InlineAutoData(false, false, true, 1)]
@@ -468,7 +468,7 @@ public class AsAtLeastNSatisfiedSpecBaseTests
         var underlying = Spec
             .Build((bool m) => m)
             .Create("underlying");
-        
+
         var spec = Spec
             .Build(underlying)
             .AsAtLeastNSatisfied(2)
@@ -478,11 +478,11 @@ public class AsAtLeastNSatisfiedSpecBaseTests
 
         // Act
         var act = result.Description.CausalOperandCount;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, false)]
     [InlineData(false, false, true, false)]
@@ -503,25 +503,25 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             Spec.Build((bool m) => m)
                 .AsAtLeastNSatisfied(2)
                 .WhenTrue(_ => "at least 2 true")
-                .WhenFalse(_ => "!at least 2 true")
-                .Create("at least 2 true");
+                .WhenFalse(_ => "¬at least 2 true")
+                .Create("at least 2 are true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
-    
+
+
     [Theory]
-    [InlineData(false, false, false, "!at least 2 true")]
-    [InlineData(false, false, true, "!at least 2 true")]
-    [InlineData(false, true, false, "!at least 2 true")]
+    [InlineData(false, false, false, "¬at least 2 true")]
+    [InlineData(false, false, true, "¬at least 2 true")]
+    [InlineData(false, true, false, "¬at least 2 true")]
     [InlineData(false, true, true, "at least 2 true")]
-    [InlineData(true, false, false, "!at least 2 true")]
+    [InlineData(true, false, false, "¬at least 2 true")]
     [InlineData(true, false, true, "at least 2 true")]
     [InlineData(true, true, false, "at least 2 true")]
     [InlineData(true, true, true, "at least 2 true")]
@@ -536,18 +536,18 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             Spec.Build((bool m) => m)
                 .AsAtLeastNSatisfied(2)
                 .WhenTrue(_ => "at least 2 true")
-                .WhenFalse(_ => "!at least 2 true")
-                .Create("at least 2 true");
+                .WhenFalse(_ => "¬at least 2 true")
+                .Create("at least 2 are true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, false)]
     [InlineData(false, false, true, false)]
@@ -572,24 +572,24 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .AsAtLeastNSatisfied(2)
                 .WhenTrue(_ => "at least 2 true")
-                .WhenFalse(_ => "!at least 2 true")
-                .Create("at least 2 true");
+                .WhenFalse(_ => "¬at least 2 true")
+                .Create("at least 2 are true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
-    [InlineData(false, false, false, "!at least 2 true")]
-    [InlineData(false, false, true, "!at least 2 true")]
-    [InlineData(false, true, false, "!at least 2 true")]
+    [InlineData(false, false, false, "¬at least 2 true")]
+    [InlineData(false, false, true, "¬at least 2 true")]
+    [InlineData(false, true, false, "¬at least 2 true")]
     [InlineData(false, true, true, "at least 2 true")]
-    [InlineData(true, false, false, "!at least 2 true")]
+    [InlineData(true, false, false, "¬at least 2 true")]
     [InlineData(true, false, true, "at least 2 true")]
     [InlineData(true, true, false, "at least 2 true")]
     [InlineData(true, true, true, "at least 2 true")]
@@ -609,8 +609,8 @@ public class AsAtLeastNSatisfiedSpecBaseTests
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .AsAtLeastNSatisfied(2)
                 .WhenTrue(_ => "at least 2 true")
-                .WhenFalse(_ => "!at least 2 true")
-                .Create("at least 2 true");
+                .WhenFalse(_ => "¬at least 2 true")
+                .Create("at least 2 are true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 

--- a/Motiv.Tests/AsAtMostNSatisfiedSpecTests.cs
+++ b/Motiv.Tests/AsAtMostNSatisfiedSpecTests.cs
@@ -39,12 +39,12 @@ public class AsAtMostNSatisfiedSpecTests
             .WhenTrue("none are satisfied")
             .WhenFalse("one or more are satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third, fourth]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -85,12 +85,12 @@ public class AsAtMostNSatisfiedSpecTests
             .WhenTrue("one is satisfied")
             .WhenFalse("none or more than one is not satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third, fourth]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -131,12 +131,12 @@ public class AsAtMostNSatisfiedSpecTests
             .WhenTrue("at most two are satisfied")
             .WhenFalse("more than two are satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third, fourth]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -178,12 +178,12 @@ public class AsAtMostNSatisfiedSpecTests
             .WhenTrue("at most four are satisfied")
             .WhenFalse("more than four are satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third, fourth]);
 
-        // Act  
+        // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -247,12 +247,12 @@ public class AsAtMostNSatisfiedSpecTests
             .WhenTrue("at most one is satisfied")
             .WhenFalse("more than one is satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third]);
-        
+
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -316,12 +316,12 @@ public class AsAtMostNSatisfiedSpecTests
             .WhenTrue("at most one is satisfied")
             .WhenFalse("more than one is satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -329,9 +329,9 @@ public class AsAtMostNSatisfiedSpecTests
     [Theory]
     [InlineAutoData(false, false, false, """
                                             at most one is satisfied
-                                                !is true
-                                                !is true
-                                                !is true
+                                                ¬is true
+                                                ¬is true
+                                                ¬is true
                                             """)]
     [InlineAutoData(false, false, true,  """
                                             at most one is satisfied
@@ -367,7 +367,7 @@ public class AsAtMostNSatisfiedSpecTests
                                                 is true
                                             """)]
     public void Should_serialize_the_result_of_the_all_operation(
-        bool first, 
+        bool first,
         bool second,
         bool third,
         string expected)
@@ -385,12 +385,12 @@ public class AsAtMostNSatisfiedSpecTests
             .WhenTrue("at most one is satisfied")
             .WhenFalse("more than one is satisfied")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -415,7 +415,7 @@ public class AsAtMostNSatisfiedSpecTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -440,11 +440,11 @@ public class AsAtMostNSatisfiedSpecTests
 
         // Act
         var act = spec.ToString();
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, false, 3)]
     [InlineAutoData(false, false, true, 1)]
@@ -464,7 +464,7 @@ public class AsAtMostNSatisfiedSpecTests
         var underlying = Spec
             .Build((bool m) => m)
             .Create("underlying");
-        
+
         var spec = Spec
             .Build(underlying)
             .AsAtMostNSatisfied(2)
@@ -474,11 +474,11 @@ public class AsAtMostNSatisfiedSpecTests
 
         // Act
         var act = result.Description.CausalOperandCount;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, true)]
     [InlineData(false, false, true, true)]
@@ -499,27 +499,27 @@ public class AsAtMostNSatisfiedSpecTests
             Spec.Build((bool m) => m)
                 .AsAtMostNSatisfied(1)
                 .WhenTrue(_ => "at most 1 true")
-                .WhenFalse(_ => "!at most 1 true")
-                .Create("at most 1 true");
+                .WhenFalse(_ => "¬at most 1 true")
+                .Create("at most 1 is true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, "at most 1 true")]
     [InlineData(false, false, true, "at most 1 true")]
     [InlineData(false, true, false, "at most 1 true")]
-    [InlineData(false, true, true, "!at most 1 true")]
+    [InlineData(false, true, true, "¬at most 1 true")]
     [InlineData(true, false, false, "at most 1 true")]
-    [InlineData(true, false, true, "!at most 1 true")]
-    [InlineData(true, true, false, "!at most 1 true")]
-    [InlineData(true, true, true, "!at most 1 true")]
+    [InlineData(true, false, true, "¬at most 1 true")]
+    [InlineData(true, true, false, "¬at most 1 true")]
+    [InlineData(true, true, true, "¬at most 1 true")]
     public void Should_provide_a_reason_for_an_at_most_n_satisfied_operation_when_using_a_boolean_predicate_function(
         bool first,
         bool second,
@@ -531,18 +531,18 @@ public class AsAtMostNSatisfiedSpecTests
             Spec.Build((bool m) => m)
                 .AsAtMostNSatisfied(1)
                 .WhenTrue(_ => "at most 1 true")
-                .WhenFalse(_ => "!at most 1 true")
-                .Create("at most 1 true");
+                .WhenFalse(_ => "¬at most 1 true")
+                .Create("at most 1 is true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, true)]
     [InlineData(false, false, true, true)]
@@ -567,27 +567,27 @@ public class AsAtMostNSatisfiedSpecTests
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .AsAtMostNSatisfied(1)
                 .WhenTrue(_ => "at most 1 true")
-                .WhenFalse(_ => "!at most 1 true")
-                .Create("at most 1 true");
+                .WhenFalse(_ => "¬at most 1 true")
+                .Create("at most 1 is true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, "at most 1 true")]
     [InlineData(false, false, true, "at most 1 true")]
     [InlineData(false, true, false, "at most 1 true")]
-    [InlineData(false, true, true, "!at most 1 true")]
+    [InlineData(false, true, true, "¬at most 1 true")]
     [InlineData(true, false, false, "at most 1 true")]
-    [InlineData(true, false, true, "!at most 1 true")]
-    [InlineData(true, true, false, "!at most 1 true")]
-    [InlineData(true, true, true, "!at most 1 true")]
+    [InlineData(true, false, true, "¬at most 1 true")]
+    [InlineData(true, true, false, "¬at most 1 true")]
+    [InlineData(true, true, true, "¬at most 1 true")]
     public void Should_provide_a_reason_for_an_at_most_n_satisfied_operation_when_using_a_boolean_result_predicate_function(
         bool first,
         bool second,
@@ -603,13 +603,13 @@ public class AsAtMostNSatisfiedSpecTests
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .AsAtMostNSatisfied(1)
                 .WhenTrue(_ => "at most 1 true")
-                .WhenFalse(_ => "!at most 1 true")
-                .Create("at most 1 true");
+                .WhenFalse(_ => "¬at most 1 true")
+                .Create("at most 1 is true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         var act = result.Reason;
-        
+
         act.Should().Be(expectedReason);
     }
 }

--- a/Motiv.Tests/AsNSatisfiedSpecTests.cs
+++ b/Motiv.Tests/AsNSatisfiedSpecTests.cs
@@ -30,11 +30,11 @@ public class AsNSatisfiedSpecTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(1, 3, 5, 7, false)]
     [InlineData(1, 3, 5, 6, false)]
@@ -66,11 +66,11 @@ public class AsNSatisfiedSpecTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(1, 3, 5, 7, "The pack does not contain exactly a pair of even numbers")]
     [InlineData(1, 3, 5, 6, "The pack does not contain exactly a pair of even numbers")]
@@ -102,11 +102,11 @@ public class AsNSatisfiedSpecTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedShallowAssertionSerialized);
     }
-    
+
     [Theory]
     [InlineData(1, 3, 5, 7, "1 is odd, 3 is odd, 5 is odd, 7 is odd")]
     [InlineData(1, 3, 5, 6, "6 is even")]
@@ -139,11 +139,11 @@ public class AsNSatisfiedSpecTests
 
         // Act
         var act = result.Explanation.Underlying;
-        
+
         // Assert
         act.GetAssertions().Should().BeEquivalentTo(expectedDeepAssertions);
     }
-    
+
     [Theory]
     [InlineAutoData(true, true, "2 even")]
     [InlineAutoData(true, false, "1 even and 1 odd")]
@@ -167,16 +167,16 @@ public class AsNSatisfiedSpecTests
             .WhenTrue("2 even")
             .WhenFalse(evaluation => $"{evaluation.TrueCount} even and {evaluation.FalseCount} odd")
             .Create();
-        
+
         var result = spec.IsSatisfiedBy([first, second]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Fact]
     public void Should_describe_an_NSatisfied_spec()
     {
@@ -196,11 +196,11 @@ public class AsNSatisfiedSpecTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be("a pair of even numbers");
     }
-    
+
     [Theory]
     [InlineData(false, false, false, false)]
     [InlineData(false, false, true, false)]
@@ -226,19 +226,19 @@ public class AsNSatisfiedSpecTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
-    [Theory]   [InlineData(false, false, false, "!2 are true")]
-    [InlineData(false, false, true, "!2 are true")]
-    [InlineData(false, true, false, "!2 are true")]
+
+    [Theory]   [InlineData(false, false, false, "¬2 are true")]
+    [InlineData(false, false, true, "¬2 are true")]
+    [InlineData(false, true, false, "¬2 are true")]
     [InlineData(false, true, true, "2 are true")]
-    [InlineData(true, false, false, "!2 are true")]
+    [InlineData(true, false, false, "¬2 are true")]
     [InlineData(true, false, true, "2 are true")]
     [InlineData(true, true, false, "2 are true")]
-    [InlineData(true, true, true, "!2 are true")]
+    [InlineData(true, true, true, "¬2 are true")]
     public void Should_perform_a_none_satisfied_operation_when_using_a_boolean_predicate_function(
         bool first,
         bool second,
@@ -255,11 +255,11 @@ public class AsNSatisfiedSpecTests
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, false)]
     [InlineData(false, false, true, false)]
@@ -280,27 +280,27 @@ public class AsNSatisfiedSpecTests
             Spec.Build((bool m) => m)
                 .AsNSatisfied(2)
                 .WhenTrue(_ => "2 are true")
-                .WhenFalse(_ => "!2 are true")
-                .Create("none are true");
+                .WhenFalse(_ => "¬2 are true")
+                .Create("none true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
-    [InlineData(false, false, false, "!2 are true")]
-    [InlineData(false, false, true, "!2 are true")]
-    [InlineData(false, true, false, "!2 are true")]
+    [InlineData(false, false, false, "¬2 are true")]
+    [InlineData(false, false, true, "¬2 are true")]
+    [InlineData(false, true, false, "¬2 are true")]
     [InlineData(false, true, true, "2 are true")]
-    [InlineData(true, false, false, "!2 are true")]
+    [InlineData(true, false, false, "¬2 are true")]
     [InlineData(true, false, true, "2 are true")]
     [InlineData(true, true, false, "2 are true")]
-    [InlineData(true, true, true, "!2 are true")]
+    [InlineData(true, true, true, "¬2 are true")]
     public void Should_provide_a_reason_for_an_n_satisfied_operation_when_using_a_boolean_result_predicate_function_with_metadata(
         bool first,
         bool second,
@@ -311,18 +311,18 @@ public class AsNSatisfiedSpecTests
             Spec.Build((bool m) => m)
                 .AsNSatisfied(2)
                 .WhenTrue(_ => "2 are true")
-                .WhenFalse(_ => "!2 are true")
-                .Create("none are true");
+                .WhenFalse(_ => "¬2 are true")
+                .Create("none true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, false)]
     [InlineData(false, false, true, false)]   [InlineData(false, true, false, false)]
@@ -346,27 +346,27 @@ public class AsNSatisfiedSpecTests
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .AsNSatisfied(2)
                 .WhenTrue(_ => "2 are true")
-                .WhenFalse(_ => "!2 are true")
-                .Create("2 are true");
+                .WhenFalse(_ => "¬2 are true")
+                .Create("2 true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
-    [InlineData(false, false, false, "!2 are true")]
-    [InlineData(false, false, true, "!2 are true")]
-    [InlineData(false, true, false, "!2 are true")]
+    [InlineData(false, false, false, "¬2 are true")]
+    [InlineData(false, false, true, "¬2 are true")]
+    [InlineData(false, true, false, "¬2 are true")]
     [InlineData(false, true, true, "2 are true")]
-    [InlineData(true, false, false, "!2 are true")]
+    [InlineData(true, false, false, "¬2 are true")]
     [InlineData(true, false, true, "2 are true")]
     [InlineData(true, true, false, "2 are true")]
-    [InlineData(true, true, true, "!2 are true")]
+    [InlineData(true, true, true, "¬2 are true")]
     public void Should_provide_a_reason_an_n_satisfied_operation_when_using_a_boolean_result_predicate_function(
         bool first,
         bool second,
@@ -382,14 +382,14 @@ public class AsNSatisfiedSpecTests
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .AsNSatisfied(2)
                 .WhenTrue(_ => "2 are true")
-                .WhenFalse(_ => "!2 are true")
-                .Create("2 are true");
+                .WhenFalse(_ => "¬2 are true")
+                .Create("2 true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }

--- a/Motiv.Tests/AsNoneSatisfiedSpecTests.cs
+++ b/Motiv.Tests/AsNoneSatisfiedSpecTests.cs
@@ -33,7 +33,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -46,34 +46,34 @@ public class AsNoneSatisfiedSpecTests
                                              false
                                          """)]
     [InlineAutoData(false, false, true, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                         """)]
     [InlineAutoData(false, true, false, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                         """)]
     [InlineAutoData(false, true, true, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                             true
                                         """)]
     [InlineAutoData(true, false, false, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                         """)]
     [InlineAutoData(true, false, true, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                             true
                                         """)]
     [InlineAutoData(true, true, false, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                             true
                                         """)]
     [InlineAutoData(true, true, true, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                             true
                                             true
@@ -102,7 +102,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -115,34 +115,34 @@ public class AsNoneSatisfiedSpecTests
                                             false
                                         """)]
     [InlineAutoData(false, false, true, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                         """)]
     [InlineAutoData(false, true, false, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                         """)]
     [InlineAutoData(false, true, true, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                             true
                                         """)]
     [InlineAutoData(true, false, false, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                         """)]
     [InlineAutoData(true, false, true, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                             true
                                         """)]
     [InlineAutoData(true, true, false, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                             true
                                         """)]
     [InlineAutoData(true, true, true, """
-                                        !none are true
+                                        ¬none are true
                                             true
                                             true
                                             true
@@ -173,7 +173,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -181,39 +181,39 @@ public class AsNoneSatisfiedSpecTests
     [Theory]
     [InlineAutoData(false, false, false, """
                                         none are true
-                                            !is true
-                                            !is true
-                                            !is true
+                                            ¬is true
+                                            ¬is true
+                                            ¬is true
                                         """)]
     [InlineAutoData(false, false, true, """
-                                        !none are true
+                                        ¬none are true
                                             is true
                                         """)]
     [InlineAutoData(false, true, false, """
-                                        !none are true
+                                        ¬none are true
                                             is true
                                         """)]
     [InlineAutoData(false, true, true, """
-                                        !none are true
+                                        ¬none are true
                                             is true
                                             is true
                                         """)]
     [InlineAutoData(true, false, false, """
-                                        !none are true
+                                        ¬none are true
                                             is true
                                         """)]
     [InlineAutoData(true, false, true, """
-                                       !none are true
+                                       ¬none are true
                                            is true
                                            is true
                                        """)]
     [InlineAutoData(true, true, false, """
-                                       !none are true
+                                       ¬none are true
                                            is true
                                            is true
                                        """)]
     [InlineAutoData(true, true, true, """
-                                      !none are true
+                                      ¬none are true
                                           is true
                                           is true
                                           is true
@@ -242,7 +242,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -251,29 +251,29 @@ public class AsNoneSatisfiedSpecTests
     [InlineAutoData(false, false, false, """
                                         none are true
                                             AND
-                                                !left
-                                                !right
+                                                ¬left
+                                                ¬right
                                             AND
-                                                !left
-                                                !right
+                                                ¬left
+                                                ¬right
                                             AND
-                                                !left
-                                                !right
+                                                ¬left
+                                                ¬right
                                         """)]
     [InlineAutoData(false, false, true, """
-                                        !none are true
+                                        ¬none are true
                                             AND
                                                 left
                                                 right
                                         """)]
     [InlineAutoData(false, true, false, """
-                                        !none are true
+                                        ¬none are true
                                             AND
                                                 left
                                                 right
                                         """)]
     [InlineAutoData(false, true, true, """
-                                        !none are true
+                                        ¬none are true
                                             AND
                                                 left
                                                 right
@@ -282,13 +282,13 @@ public class AsNoneSatisfiedSpecTests
                                                 right
                                         """)]
     [InlineAutoData(true, false, false, """
-                                        !none are true
+                                        ¬none are true
                                             AND
                                                 left
                                                 right
                                         """)]
     [InlineAutoData(true, false, true, """
-                                        !none are true
+                                        ¬none are true
                                             AND
                                                 left
                                                 right
@@ -297,7 +297,7 @@ public class AsNoneSatisfiedSpecTests
                                                 right
                                         """)]
     [InlineAutoData(true, true, false, """
-                                        !none are true
+                                        ¬none are true
                                             AND
                                                 left
                                                 right
@@ -306,7 +306,7 @@ public class AsNoneSatisfiedSpecTests
                                                 right
                                         """)]
     [InlineAutoData(true, true, true, """
-                                        !none are true
+                                        ¬none are true
                                             AND
                                                 left
                                                 right
@@ -347,20 +347,20 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = result.Justification;
-        
+
         // Assert
         act.Should().Be(expected);
     }
 
     [Theory]
     [InlineAutoData(false, false, false, "none are true")]
-    [InlineAutoData(false, false, true, "!none are true")]
-    [InlineAutoData(false, true, false, "!none are true")]
-    [InlineAutoData(false, true, true, "!none are true")]
-    [InlineAutoData(true, false, false, "!none are true")]
-    [InlineAutoData(true, false, true, "!none are true")]
-    [InlineAutoData(true, true, false, "!none are true")]
-    [InlineAutoData(true, true, true, "!none are true")]
+    [InlineAutoData(false, false, true, "¬none are true")]
+    [InlineAutoData(false, true, false, "¬none are true")]
+    [InlineAutoData(false, true, true, "¬none are true")]
+    [InlineAutoData(true, false, false, "¬none are true")]
+    [InlineAutoData(true, false, true, "¬none are true")]
+    [InlineAutoData(true, true, false, "¬none are true")]
+    [InlineAutoData(true, true, true, "¬none are true")]
     public void Should_Describe_the_result_of_the_all_operation_and_show_multiple_underlying_causes(
         bool first,
         bool second,
@@ -391,20 +391,20 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineAutoData(false, false, false, "none are true")]
-    [InlineAutoData(false, false, true, "!none are true")]
-    [InlineAutoData(false, true, false, "!none are true")]
-    [InlineAutoData(false, true, true, "!none are true")]
-    [InlineAutoData(true, false, false, "!none are true")]
-    [InlineAutoData(true, false, true, "!none are true")]
-    [InlineAutoData(true, true, false, "!none are true")]
-    [InlineAutoData(true, true, true, "!none are true")]
+    [InlineAutoData(false, false, true, "¬none are true")]
+    [InlineAutoData(false, true, false, "¬none are true")]
+    [InlineAutoData(false, true, true, "¬none are true")]
+    [InlineAutoData(true, false, false, "¬none are true")]
+    [InlineAutoData(true, false, true, "¬none are true")]
+    [InlineAutoData(true, true, false, "¬none are true")]
+    [InlineAutoData(true, true, true, "¬none are true")]
     public void Should_serialize_the_result_of_the_all_operation_and_show_multiple_underlying_causes(
         bool first,
         bool second,
@@ -435,7 +435,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = result.ToString();
-        
+
         // Assert
         act.Should().Be(expected);
     }
@@ -461,7 +461,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be(expectedSummary);
     }
@@ -491,7 +491,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = spec.Expression;
-        
+
         // Assert
         act.Should().Be(expectedFull);
     }
@@ -517,7 +517,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be(expectedSummary);
     }
@@ -547,7 +547,7 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = spec.Expression;
-        
+
         // Assert
         act.Should().Be(expectedFull);
     }
@@ -573,12 +573,12 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = spec.ToString();
-        
+
         // Assert
         act.Should().Be(expectedSummary);
     }
 
-    [Fact]  
+    [Fact]
     public void Should_provide_a_description_of_the_specification_when_metadata_is_a_string()
     {
         // Arrange
@@ -599,11 +599,11 @@ public class AsNoneSatisfiedSpecTests
 
         // Act
         var act = spec.ToString();
-        
+
         // Assert
         act.Should().Be(expectedSummary);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, true)]
     [InlineData(false, false, true, false)]
@@ -624,27 +624,27 @@ public class AsNoneSatisfiedSpecTests
             Spec.Build((bool m) => m)
                 .AsNoneSatisfied()
                 .WhenTrue(_ => "none are true")
-                .WhenFalse(_ => "!none are true")
-                .Create("none are true");
+                .WhenFalse(_ => "¬none are true")
+                .Create("none true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
-        
+
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, "none are true")]
-    [InlineData(false, false, true, "!none are true")]
-    [InlineData(false, true, false, "!none are true")]
-    [InlineData(false, true, true, "!none are true")]
-    [InlineData(true, false, false, "!none are true")]
-    [InlineData(true, false, true, "!none are true")]
-    [InlineData(true, true, false, "!none are true")]
-    [InlineData(true, true, true, "!none are true")]
+    [InlineData(false, false, true, "¬none are true")]
+    [InlineData(false, true, false, "¬none are true")]
+    [InlineData(false, true, true, "¬none are true")]
+    [InlineData(true, false, false, "¬none are true")]
+    [InlineData(true, false, true, "¬none are true")]
+    [InlineData(true, true, false, "¬none are true")]
+    [InlineData(true, true, true, "¬none are true")]
     public void Should_provide_a_reason_for_a_none_satisfied_operation_when_using_a_boolean_predicate_function(
         bool first,
         bool second,
@@ -656,18 +656,18 @@ public class AsNoneSatisfiedSpecTests
             Spec.Build((bool m) => m)
                 .AsNoneSatisfied()
                 .WhenTrue(_ => "none are true")
-                .WhenFalse(_ => "!none are true")
-                .Create("none are true");
+                .WhenFalse(_ => "¬none are true")
+                .Create("none true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, true)]
     [InlineData(false, false, true, false)]
@@ -692,27 +692,27 @@ public class AsNoneSatisfiedSpecTests
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .AsNoneSatisfied()
                 .WhenTrue(_ => "none are true")
-                .WhenFalse(_ => "!none are true")
-                .Create("none are true");
+                .WhenFalse(_ => "¬none are true")
+                .Create("none true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, false, "none are true")]
-    [InlineData(false, false, true, "!none are true")]
-    [InlineData(false, true, false, "!none are true")]
-    [InlineData(false, true, true, "!none are true")]
-    [InlineData(true, false, false, "!none are true")]
-    [InlineData(true, false, true, "!none are true")]
-    [InlineData(true, true, false, "!none are true")]
-    [InlineData(true, true, true, "!none are true")]
+    [InlineData(false, false, true, "¬none are true")]
+    [InlineData(false, true, false, "¬none are true")]
+    [InlineData(false, true, true, "¬none are true")]
+    [InlineData(true, false, false, "¬none are true")]
+    [InlineData(true, false, true, "¬none are true")]
+    [InlineData(true, true, false, "¬none are true")]
+    [InlineData(true, true, true, "¬none are true")]
     public void Should_provide_a_reason_for_a_none_satisfied_operation_when_using_a_boolean_result_predicate_function(
         bool first,
         bool second,
@@ -728,14 +728,14 @@ public class AsNoneSatisfiedSpecTests
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .AsNoneSatisfied()
                 .WhenTrue(_ => "none are true")
-                .WhenFalse(_ => "!none are true")
-                .Create("none are true");
+                .WhenFalse(_ => "¬none are true")
+                .Create("none true");
 
         var result = spec.IsSatisfiedBy([first, second, third]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }

--- a/Motiv.Tests/BooleanResultPredicateExplanationPropositionTests.cs
+++ b/Motiv.Tests/BooleanResultPredicateExplanationPropositionTests.cs
@@ -18,7 +18,7 @@ public class BooleanResultPredicateExplanationPropositionTests
             .WhenTrue("underlying is true")
             .WhenFalse("underlying is false")
             .Create("are equal");
-        
+
         var firstSpec = Spec
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .WhenTrue("first is true")
@@ -49,11 +49,11 @@ public class BooleanResultPredicateExplanationPropositionTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, true)]
     [InlineData(false, true, false)]
@@ -70,7 +70,7 @@ public class BooleanResultPredicateExplanationPropositionTests
             .WhenTrue("underlying is true")
             .WhenFalse("underlying is false")
             .Create("are equal");
-        
+
         var firstSpec = Spec
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .WhenTrueYield((_, _) => ["first is true"])
@@ -95,11 +95,11 @@ public class BooleanResultPredicateExplanationPropositionTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, "underlying is true")]
     [InlineData(false, true, "underlying is false")]
@@ -116,7 +116,7 @@ public class BooleanResultPredicateExplanationPropositionTests
             .WhenTrue("underlying is true")
             .WhenFalse("underlying is false")
             .Create("are equal");
-        
+
         var firstSpec = Spec
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .WhenTrue("first is true")
@@ -147,11 +147,11 @@ public class BooleanResultPredicateExplanationPropositionTests
 
         // Act
         var act = result.RootAssertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedRootAssertion);
     }
-    
+
     [Theory]
     [InlineData(true,  "first is true", "second is true", "third is true", "fourth is true")]
     [InlineData(false,  "first is false", "second is false", "third is false", "fourth is false")]
@@ -165,7 +165,7 @@ public class BooleanResultPredicateExplanationPropositionTests
             .WhenTrue("underlying is true")
             .WhenFalse("underlying is false")
             .Create("are equal");
-        
+
         var firstSpec = Spec
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .WhenTrue("first is true")
@@ -196,11 +196,11 @@ public class BooleanResultPredicateExplanationPropositionTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedAssertions);
     }
-    
+
     [Theory]
     [InlineData(true,  "first is true", "second is true", "third is true")]
     [InlineData(false, "first is false", "second is false", "third is false")]
@@ -214,7 +214,7 @@ public class BooleanResultPredicateExplanationPropositionTests
             .WhenTrue("underlying is true")
             .WhenFalse("underlying is false")
             .Create("are equal");
-        
+
         var firstSpec = Spec
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .WhenTrueYield((_, _) => ["first is true"])
@@ -239,37 +239,37 @@ public class BooleanResultPredicateExplanationPropositionTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedAssertions);
     }
-    
+
     [Theory]
     [InlineData(true, "true")]
     [InlineData(false, "false")]
     public void Should_a_reason_from_assertions(
         bool model,
         string expectedReasonStatement)
-    { 
+    {
         // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue("true")
                 .WhenFalse("false")
                 .Create();
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue("true")
                 .WhenFalse(_ => "false")
                 .Create();
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue("true")
@@ -278,43 +278,43 @@ public class BooleanResultPredicateExplanationPropositionTests
 
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
-                   withFalseAsTwoParameterCallback; 
-        
+                   withFalseAsTwoParameterCallback;
+
         var result = spec.IsSatisfiedBy(model);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion")]
     [InlineData(false, "false assertion")]
     public void Should_use_the_propositional_statement_in_the_reason(
         bool model,
         string expectedReasonStatement)
-    { 
+    {
         // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue("true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue("true assertion")
@@ -324,19 +324,19 @@ public class BooleanResultPredicateExplanationPropositionTests
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
 
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_more_than_one_assertion_possible(
         bool model,
         string expectedReason)
@@ -345,7 +345,7 @@ public class BooleanResultPredicateExplanationPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var spec =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue("true assertion")
@@ -353,17 +353,17 @@ public class BooleanResultPredicateExplanationPropositionTests
                 .Create("propositional statement");
 
         var result = spec.IsSatisfiedBy(model);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion")]
-    [InlineData(false, "!true assertion")]
+    [InlineData(false, "¬true assertion")]
     public void Should_use_the_implicit_propositional_statement_in_the_reason_when_more_than_one_assertion_possible(
         bool model,
         string expectedReason)
@@ -372,7 +372,7 @@ public class BooleanResultPredicateExplanationPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var spec =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue("true assertion")
@@ -380,10 +380,10 @@ public class BooleanResultPredicateExplanationPropositionTests
                 .Create();
 
         var result = spec.IsSatisfiedBy(model);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
@@ -394,48 +394,48 @@ public class BooleanResultPredicateExplanationPropositionTests
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_single_parameter_callback(
         bool model,
         string expectedReasonStatement)
-    { 
+    {
         // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse((_, _) => "false assertion")
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_single_parameter_callback_when_multiple_assertion_possible(
         bool model,
         string expectedReason)
@@ -444,7 +444,7 @@ public class BooleanResultPredicateExplanationPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var spec =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => "true assertion")
@@ -452,40 +452,40 @@ public class BooleanResultPredicateExplanationPropositionTests
                 .Create("propositional statement");
 
         var result = spec.IsSatisfiedBy(model);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion")]
     [InlineData(false, "false assertion")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback(
         bool model,
         string expectedReasonStatement)
-    { 
+    {
         // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => "true assertion")
@@ -495,19 +495,19 @@ public class BooleanResultPredicateExplanationPropositionTests
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_when_multiple_assertion_possible(
         bool model,
         string expectedReason)
@@ -516,7 +516,7 @@ public class BooleanResultPredicateExplanationPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var spec =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => "true assertion")
@@ -524,67 +524,67 @@ public class BooleanResultPredicateExplanationPropositionTests
                 .Create("propositional statement");
 
         var result = spec.IsSatisfiedBy(model);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_that_returns_a_collection(
         bool model,
         string expectedReasonStatement)
-    { 
+    {
         // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => ["true assertion"])
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => ["true assertion"])
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => ["true assertion"])
                 .WhenFalse((_, _) => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => ["true assertion"])
                 .WhenFalseYield((_, _) => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
-        
+
     }
-    
+
     [Fact]
     public void Should_describe_a_boolean_result_spec()
     {
@@ -592,13 +592,13 @@ public class BooleanResultPredicateExplanationPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
-        var spec = 
+
+        var spec =
             Spec.Build((bool model) => underlying.IsSatisfiedBy(model))
                 .WhenTrue("is true")
                 .WhenFalse("is false")
                 .Create("is model true");
-           
+
         // Act
         var act = spec.Description.Statement;
 

--- a/Motiv.Tests/BooleanResultPredicateMetadataPropositionTests.cs
+++ b/Motiv.Tests/BooleanResultPredicateMetadataPropositionTests.cs
@@ -7,7 +7,7 @@ public class BooleanResultPredicateMetadataPropositionTests
         True,
         False
     }
-    
+
     [Theory]
     [InlineData(false, false, true)]
     [InlineData(false, true, false)]
@@ -24,7 +24,7 @@ public class BooleanResultPredicateMetadataPropositionTests
             .WhenTrue(100)
             .WhenFalse(-100)
             .Create("are equal");
-        
+
         var firstSpec = Spec
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .WhenTrue(200)
@@ -55,15 +55,15 @@ public class BooleanResultPredicateMetadataPropositionTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(false, false, "is first true", "is second true", "is third true", "is fourth true")]
-    [InlineData(false, true, "!is first true", "!is second true", "!is third true", "!is fourth true")]
-    [InlineData(true, false, "!is first true", "!is second true", "!is third true", "!is fourth true")]
+    [InlineData(false, true, "¬is first true", "¬is second true", "¬is third true", "¬is fourth true")]
+    [InlineData(true, false, "¬is first true", "¬is second true", "¬is third true", "¬is fourth true")]
     [InlineData(true, true, "is first true", "is second true", "is third true", "is fourth true")]
     public void Should_use_proposition_statement_when_generating_assertions_for_metadata_propositions(
         bool model,
@@ -76,7 +76,7 @@ public class BooleanResultPredicateMetadataPropositionTests
             .WhenTrue(100)
             .WhenFalse(-100)
             .Create("are equal");
-        
+
         var firstSpec = Spec
             .Build((bool m) => underlying.IsSatisfiedBy(m))
             .WhenTrue(200)
@@ -107,219 +107,219 @@ public class BooleanResultPredicateMetadataPropositionTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedAssertion);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_false_assertiom_is_callback(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_single_parameter_callback(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_that_returns_a_collection(
         bool model,
         string because)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(because, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, Metadata.True)]
     [InlineData(false, Metadata.False)]
@@ -327,49 +327,49 @@ public class BooleanResultPredicateMetadataPropositionTests
         bool model,
         Metadata expectedMetadata)
     {
-        // Arrange 
+        // Arrange
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }
-    
+
     [Theory]
     [InlineData(true, Metadata.True)]
     [InlineData(false, Metadata.False)]
@@ -377,49 +377,49 @@ public class BooleanResultPredicateMetadataPropositionTests
         bool model,
         Metadata expectedMetadata)
     {
-        // Arrange 
+        // Arrange
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.MetadataTier.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }
-    
+
     [Theory]
     [InlineData(true, Metadata.True)]
     [InlineData(false, Metadata.False)]
@@ -431,45 +431,45 @@ public class BooleanResultPredicateMetadataPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }
-    
+
     [Theory]
     [InlineData(true, Metadata.True)]
     [InlineData(false, Metadata.False)]
@@ -481,45 +481,45 @@ public class BooleanResultPredicateMetadataPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.MetadataTier.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }
-    
+
     [Theory]
     [InlineData(true, Metadata.True)]
     [InlineData(false, Metadata.False)]
@@ -531,45 +531,45 @@ public class BooleanResultPredicateMetadataPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }
-    
+
     [Theory]
     [InlineData(true, Metadata.True)]
     [InlineData(false, Metadata.False)]
@@ -581,45 +581,45 @@ public class BooleanResultPredicateMetadataPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.MetadataTier.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }
-    
+
     [Theory]
     [InlineData(true, Metadata.True)]
     [InlineData(false, Metadata.False)]
@@ -631,45 +631,45 @@ public class BooleanResultPredicateMetadataPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }
-    
+
     [Theory]
     [InlineData(true, Metadata.True)]
     [InlineData(false, Metadata.False)]
@@ -681,41 +681,41 @@ public class BooleanResultPredicateMetadataPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool b) => underlying.IsSatisfiedBy(b))
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.MetadataTier.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }

--- a/Motiv.Tests/BooleanResultTests.cs
+++ b/Motiv.Tests/BooleanResultTests.cs
@@ -267,7 +267,7 @@ public class BooleanResultTests
 
         var act = sut.Reason;
 
-        act.Should().Be("a & !(!b | !c)");
+        act.Should().Be("a & !(¬b | ¬c)");
     }
 
     [Fact]
@@ -286,7 +286,7 @@ public class BooleanResultTests
 
         var act = sut.Reason;
 
-        act.Should().Be("a && !(!b | !c)");
+        act.Should().Be("a && !(¬b | ¬c)");
     }
 
     [Fact]
@@ -305,7 +305,7 @@ public class BooleanResultTests
 
         var act = sut.Reason;
 
-        act.Should().Be("a | !(!b & !c)");
+        act.Should().Be("a | !(¬b & ¬c)");
     }
 
     [Fact]
@@ -324,7 +324,7 @@ public class BooleanResultTests
 
         var act = sut.Reason;
 
-        act.Should().Be("!a || !(b & c)");
+        act.Should().Be("¬a || !(b & c)");
     }
 
     [Theory]

--- a/Motiv.Tests/ExplanationTests.cs
+++ b/Motiv.Tests/ExplanationTests.cs
@@ -382,7 +382,7 @@ public class ExplanationTests
     }
 
     [Theory]
-    [InlineData(1, "!is even wrapper 2")]
+    [InlineData(1, "¬is even wrapper 2")]
     [InlineData(2, "is even wrapper 2")]
     public void Should_use_propositional_statement_as_assertions_when_using_basic_metadata_propositions(
         int model,

--- a/Motiv.Tests/HigherOrderExplanationBooleanResultTests.cs
+++ b/Motiv.Tests/HigherOrderExplanationBooleanResultTests.cs
@@ -27,11 +27,11 @@ public class HigherOrderExplanationBooleanResultTests
 
         // Act
         var act = result.Explanation.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
     public void Should_preserve_the_description_of_the_underlying_()
     {
@@ -51,7 +51,7 @@ public class HigherOrderExplanationBooleanResultTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be("is a pair of even numbers");
     }
@@ -80,13 +80,13 @@ public class HigherOrderExplanationBooleanResultTests
                 .WhenTrue("first all true")
                 .WhenFalse("first all false")
                 .Create();
-            
+
         var secondSpec =
             Spec.Build(firstSpec)
                 .WhenTrue("second all true")
                 .WhenFalse("second all false")
                 .Create();
-            
+
         var spec =
             Spec.Build(secondSpec)
                 .WhenTrue("third all true")
@@ -97,11 +97,11 @@ public class HigherOrderExplanationBooleanResultTests
 
         // Act
         var act = result.Explanation.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Theory]
     [InlineData(true, true, true, "is true")]
     [InlineData(true, true, false, "is false")]
@@ -126,13 +126,13 @@ public class HigherOrderExplanationBooleanResultTests
                 .WhenTrue("first true")
                 .WhenFalse("first false")
                 .Create("all even");
-            
+
         var secondSpec =
             Spec.Build(firstSpec)
                 .WhenTrue("second true")
                 .WhenFalse("second false")
                 .Create();
-            
+
         var spec =
             Spec.Build(secondSpec)
                 .WhenTrue("third true")
@@ -143,11 +143,11 @@ public class HigherOrderExplanationBooleanResultTests
 
         // Act
         var act = result.GetRootAssertions();
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Theory]
     [InlineData(2, 4, 6, 8, true)]
     [InlineData(2, 4, 6, 9, false)]
@@ -155,8 +155,8 @@ public class HigherOrderExplanationBooleanResultTests
     [InlineData(1, 3, 6, 9, false)]
     [InlineData(1, 3, 5, 9, false)]
     public void Should_satisfy_regular_true_assertion_yield_to_be_used_with_a_higher_order_yield_of_false_assertions(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         bool expected)
@@ -177,7 +177,7 @@ public class HigherOrderExplanationBooleanResultTests
                     var serializedModels = results.CausalModels.Serialize();
                     var modelCount = results.CausalModels.Count;
                     var isOrAre = modelCount == 1 ? "is" : "are";
-                    
+
                     return $"not all even: {serializedModels} {isOrAre} odd";
                 })
                 .Create();
@@ -186,12 +186,12 @@ public class HigherOrderExplanationBooleanResultTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
-    
+
+
     [Theory]
     [InlineData(2, 4, 6, 8, "all even")]
     [InlineData(2, 4, 6, 9, "not all even: 9 is odd")]
@@ -199,8 +199,8 @@ public class HigherOrderExplanationBooleanResultTests
     [InlineData(1, 3, 6, 9, "not all even: 1, 3, and 9 are odd")]
     [InlineData(1, 3, 5, 9, "not all even: 1, 3, 5, and 9 are odd")]
     public void Should_assert_regular_true_assertion_yield_to_be_used_with_a_higher_order_yield_of_false_assertions(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         string expectedReason)
@@ -221,7 +221,7 @@ public class HigherOrderExplanationBooleanResultTests
                     var serializedModels = results.CausalModels.Serialize();
                     var modelCount = results.CausalModels.Count;
                     var isOrAre = modelCount == 1 ? "is" : "are";
-                    
+
                     return $"not all even: {serializedModels} {isOrAre} odd";
                 })
                 .Create();
@@ -230,12 +230,12 @@ public class HigherOrderExplanationBooleanResultTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedReason);
     }
-    
-    
+
+
     [Theory]
     [InlineData(true, "true assertion")]
     [InlineData(false, "false assertion")]
@@ -243,20 +243,20 @@ public class HigherOrderExplanationBooleanResultTests
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 2));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create();
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
@@ -265,19 +265,19 @@ public class HigherOrderExplanationBooleanResultTests
                 .Create();
 
         var spec = withFalseAsScalar & withFalseAsParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy([model]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion",  "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!true assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬true assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason(
         bool model,
         string expectedAssertion,
@@ -290,56 +290,56 @@ public class HigherOrderExplanationBooleanResultTests
             expectedAssertion,
             expectedReasonStatement,
             expectedImplicitAssertion);
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallback =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallbackThatReturnsACollection =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollectionWithImpliedName =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create();
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsCallback &
                    withFalseAsCallbackThatReturnsACollection &
                    withFalseAsTwoParameterCallbackThatReturnsACollectionWithImpliedName;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_single_parameter_callback(
         bool model,
         string expectedAssertion,
@@ -351,159 +351,159 @@ public class HigherOrderExplanationBooleanResultTests
             expectedAssertion,
             expectedAssertion,
             expectedReasonStatement);
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback(
         bool model,
         string expectedAssertion,
         string expectedReasonStatement)
     {
-        // Arrange 
-        var expectedReason = string.Join(" & ", 
+        // Arrange
+        var expectedReason = string.Join(" & ",
             expectedAssertion,
             expectedAssertion,
             expectedAssertion,
             expectedReasonStatement);
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_that_returns_a_collection(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallback =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
-        
+
+
         var withFalseAsCallbackThatReturnsACollection =
             Spec.Build((bool m) => underlying.IsSatisfiedBy(m))
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsCallback &
                    withFalseAsCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }

--- a/Motiv.Tests/HigherOrderExplanationPredicateTests.cs
+++ b/Motiv.Tests/HigherOrderExplanationPredicateTests.cs
@@ -21,11 +21,11 @@ public class HigherOrderExplanationPredicateTests
 
         // Act
         var act = result.Explanation.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
     public void Should_preserve_the_description_of_the_underlying_()
     {
@@ -39,7 +39,7 @@ public class HigherOrderExplanationPredicateTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be("is a pair of even numbers");
     }
@@ -63,13 +63,13 @@ public class HigherOrderExplanationPredicateTests
                 .WhenTrue("first all true")
                 .WhenFalse("first all false")
                 .Create();
-            
+
         var secondSpec =
             Spec.Build(firstSpec)
                 .WhenTrue("second all true")
                 .WhenFalse("second all false")
                 .Create();
-            
+
         var spec =
             Spec.Build(secondSpec)
                 .WhenTrue("third all true")
@@ -80,11 +80,11 @@ public class HigherOrderExplanationPredicateTests
 
         // Act
         var act = result.Explanation.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Theory]
     [InlineData(true, true, true, "first true")]
     [InlineData(true, true, false, "first false")]
@@ -103,13 +103,13 @@ public class HigherOrderExplanationPredicateTests
                 .WhenTrue("first true")
                 .WhenFalse("first false")
                 .Create("all even");
-            
+
         var secondSpec =
             Spec.Build(firstSpec)
                 .WhenTrue("second true")
                 .WhenFalse("second false")
                 .Create();
-            
+
         var spec =
             Spec.Build(secondSpec)
                 .WhenTrue("third true")
@@ -120,11 +120,11 @@ public class HigherOrderExplanationPredicateTests
 
         // Act
         var act = result.GetRootAssertions();
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Theory]
     [InlineData(2, 4, 6, 8, true)]
     [InlineData(2, 4, 6, 9, false)]
@@ -132,8 +132,8 @@ public class HigherOrderExplanationPredicateTests
     [InlineData(1, 3, 6, 9, false)]
     [InlineData(1, 3, 5, 9, false)]
     public void Should_satisfy_regular_true_assertion_yield_to_be_used_with_a_higher_order_yield_of_false_assertions(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         bool expected)
@@ -148,7 +148,7 @@ public class HigherOrderExplanationPredicateTests
                     var serializedModels = results.CausalModels.Serialize();
                     var modelCount = results.CausalModels.Count;
                     var isOrAre = modelCount == 1 ? "is" : "are";
-                    
+
                     return $"not all even: {serializedModels} {isOrAre} odd";
                 })
                 .Create();
@@ -157,12 +157,12 @@ public class HigherOrderExplanationPredicateTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
-    
+
+
     [Theory]
     [InlineData(2, 4, 6, 8, "all even")]
     [InlineData(2, 4, 6, 9, "not all even: 9 is odd")]
@@ -170,8 +170,8 @@ public class HigherOrderExplanationPredicateTests
     [InlineData(1, 3, 6, 9, "not all even: 1, 3, and 9 are odd")]
     [InlineData(1, 3, 5, 9, "not all even: 1, 3, 5, and 9 are odd")]
     public void Should_assert_regular_true_assertion_yield_to_be_used_with_a_higher_order_yield_of_false_assertions(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         string expectedReason)
@@ -186,7 +186,7 @@ public class HigherOrderExplanationPredicateTests
                     var serializedModels = results.CausalModels.Serialize();
                     var modelCount = results.CausalModels.Count;
                     var isOrAre = modelCount == 1 ? "is" : "are";
-                    
+
                     return $"not all even: {serializedModels} {isOrAre} odd";
                 })
                 .Create();
@@ -195,12 +195,12 @@ public class HigherOrderExplanationPredicateTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedReason);
     }
-    
-    
+
+
     [Theory]
     [InlineData(true, "true assertion")]
     [InlineData(false, "false assertion")]
@@ -208,17 +208,17 @@ public class HigherOrderExplanationPredicateTests
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 2));
-        
-        
+
+
         var withFalseAsScalar =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create();
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
@@ -227,19 +227,19 @@ public class HigherOrderExplanationPredicateTests
                 .Create();
 
         var spec = withFalseAsScalar & withFalseAsParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy([model]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion",  "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!true assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬true assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason(
         bool model,
         string expectedAssertion,
@@ -252,52 +252,52 @@ public class HigherOrderExplanationPredicateTests
             expectedAssertion,
             expectedReasonStatement,
             expectedImplicitAssertion);
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallback =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallbackThatReturnsACollection =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollectionWithImpliedName =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create();
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsCallback &
                    withFalseAsCallbackThatReturnsACollection &
                    withFalseAsTwoParameterCallbackThatReturnsACollectionWithImpliedName;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_single_parameter_callback(
         bool model,
         string expectedAssertion,
@@ -309,146 +309,146 @@ public class HigherOrderExplanationPredicateTests
             expectedAssertion,
             expectedAssertion,
             expectedReasonStatement);
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback(
         bool model,
         string expectedAssertion,
         string expectedReasonStatement)
     {
-        // Arrange 
-        var expectedReason = string.Join(" & ", 
+        // Arrange
+        var expectedReason = string.Join(" & ",
             expectedAssertion,
             expectedAssertion,
             expectedAssertion,
             expectedReasonStatement);
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_that_returns_a_collection(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var withFalseAsScalar =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallback =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallbackThatReturnsACollection =
             Spec.Build((bool m) => m)
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsCallback &
                    withFalseAsCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }

--- a/Motiv.Tests/HigherOrderExplanationSpecTests.cs
+++ b/Motiv.Tests/HigherOrderExplanationSpecTests.cs
@@ -27,11 +27,11 @@ public class HigherOrderExplanationSpecTests
 
         // Act
         var act = result.Explanation.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
     public void Should_preserve_the_description_of_the_underlying_()
     {
@@ -51,7 +51,7 @@ public class HigherOrderExplanationSpecTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be("is a pair of even numbers");
     }
@@ -80,13 +80,13 @@ public class HigherOrderExplanationSpecTests
                 .WhenTrue("first all true")
                 .WhenFalse("first all false")
                 .Create();
-            
+
         var secondSpec =
             Spec.Build(firstSpec)
                 .WhenTrue("second all true")
                 .WhenFalse("second all false")
                 .Create();
-            
+
         var spec =
             Spec.Build(secondSpec)
                 .WhenTrue("third all true")
@@ -97,11 +97,11 @@ public class HigherOrderExplanationSpecTests
 
         // Act
         var act = result.Explanation.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Theory]
     [InlineData(true, true, true, "is true")]
     [InlineData(true, true, false, "is false")]
@@ -125,13 +125,13 @@ public class HigherOrderExplanationSpecTests
                 .WhenTrue("first true")
                 .WhenFalse("first false")
                 .Create("all even");
-            
+
         var secondSpec =
             Spec.Build(firstSpec)
                 .WhenTrue("second true")
                 .WhenFalse("second false")
                 .Create();
-            
+
         var spec =
             Spec.Build(secondSpec)
                 .WhenTrue("third true")
@@ -142,11 +142,11 @@ public class HigherOrderExplanationSpecTests
 
         // Act
         var act = result.GetRootAssertions();
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Theory]
     [InlineData(2, 4, 6, 8, true)]
     [InlineData(2, 4, 6, 9, false)]
@@ -154,8 +154,8 @@ public class HigherOrderExplanationSpecTests
     [InlineData(1, 3, 6, 9, false)]
     [InlineData(1, 3, 5, 9, false)]
     public void Should_satisfy_regular_true_assertion_yield_to_be_used_with_a_higher_order_yield_of_false_assertions(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         bool expected)
@@ -176,7 +176,7 @@ public class HigherOrderExplanationSpecTests
                     var serializedModels = results.CausalModels.Serialize();
                     var modelCount = results.CausalModels.Count;
                     var isOrAre = modelCount == 1 ? "is" : "are";
-                    
+
                     return $"not all even: {serializedModels} {isOrAre} odd";
                 })
                 .Create();
@@ -185,12 +185,12 @@ public class HigherOrderExplanationSpecTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
-    
+
+
     [Theory]
     [InlineData(2, 4, 6, 8, "all even")]
     [InlineData(2, 4, 6, 9, "not all even: 9 is odd")]
@@ -198,8 +198,8 @@ public class HigherOrderExplanationSpecTests
     [InlineData(1, 3, 6, 9, "not all even: 1, 3, and 9 are odd")]
     [InlineData(1, 3, 5, 9, "not all even: 1, 3, 5, and 9 are odd")]
     public void Should_assert_regular_true_assertion_yield_to_be_used_with_a_higher_order_yield_of_false_assertions(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         string expectedReason)
@@ -220,7 +220,7 @@ public class HigherOrderExplanationSpecTests
                     var serializedModels = results.CausalModels.Serialize();
                     var modelCount = results.CausalModels.Count;
                     var isOrAre = modelCount == 1 ? "is" : "are";
-                    
+
                     return $"not all even: {serializedModels} {isOrAre} odd";
                 })
                 .Create();
@@ -229,12 +229,12 @@ public class HigherOrderExplanationSpecTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedReason);
     }
-    
-    
+
+
     [Theory]
     [InlineData(true, "true assertion")]
     [InlineData(false, "false assertion")]
@@ -242,20 +242,20 @@ public class HigherOrderExplanationSpecTests
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 2));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create();
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .AsAllSatisfied()
@@ -264,19 +264,19 @@ public class HigherOrderExplanationSpecTests
                 .Create();
 
         var spec = withFalseAsScalar & withFalseAsParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy([model]);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion",  "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!true assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬true assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason(
         bool model,
         string expectedAssertion,
@@ -289,56 +289,56 @@ public class HigherOrderExplanationSpecTests
             expectedAssertion,
             expectedReasonStatement,
             expectedImplicitAssertion);
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallback =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollectionWithImpliedName =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue("true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create();
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsCallback &
                    withFalseAsCallbackThatReturnsACollection &
                    withFalseAsTwoParameterCallbackThatReturnsACollectionWithImpliedName;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_single_parameter_callback(
         bool model,
         string expectedAssertion,
@@ -350,159 +350,159 @@ public class HigherOrderExplanationSpecTests
             expectedAssertion,
             expectedAssertion,
             expectedReasonStatement);
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion", "propositional statement")]
-    [InlineData(false, "false assertion", "!propositional statement")]
+    [InlineData(false, "false assertion", "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback(
         bool model,
         string expectedAssertion,
         string expectedReasonStatement)
     {
-        // Arrange 
-        var expectedReason = string.Join(" & ", 
+        // Arrange
+        var expectedReason = string.Join(" & ",
             expectedAssertion,
             expectedAssertion,
             expectedAssertion,
             expectedReasonStatement);
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrue(_ => "true assertion")
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_that_returns_a_collection(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsCallback =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
-        
+
+
         var withFalseAsCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .AsAllSatisfied()
                 .WhenTrueYield(_ => ["true assertion"])
                 .WhenFalseYield(_ => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsCallback &
                    withFalseAsCallbackThatReturnsACollection;
 
         var result = spec.IsSatisfiedBy([model]);
-        
+
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }

--- a/Motiv.Tests/HigherOrderMetadataSpecTests.cs
+++ b/Motiv.Tests/HigherOrderMetadataSpecTests.cs
@@ -8,7 +8,7 @@ public class HigherOrderMetadataSpecTests
         True,
         False
     }
-    
+
     [Theory]
     [InlineData(1, 3, 5, 7, Metadata.False)]
     [InlineData(1, 3, 5, 8, Metadata.False)]
@@ -34,11 +34,11 @@ public class HigherOrderMetadataSpecTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expected]);
     }
-    
+
     [Fact]
     public void Should_preserve_the_description_of_the_underlying_()
     {
@@ -58,7 +58,7 @@ public class HigherOrderMetadataSpecTests
 
         // Act
         var act = spec.Statement;
-        
+
         // Assert
         act.Should().Be("is a pair of even numbers");
     }
@@ -80,7 +80,7 @@ public class HigherOrderMetadataSpecTests
     {
         // Arrange
         var expected = (3, expectedMetadata);
-        
+
         var underlying =
             Spec.Build((bool b) => b)
                 .WhenTrue(_ => Guid.NewGuid())
@@ -93,13 +93,13 @@ public class HigherOrderMetadataSpecTests
                 .WhenTrue((1, Metadata.True))
                 .WhenFalse((1, Metadata.False))
                 .Create("first all true");
-            
+
         var secondSpec =
             Spec.Build(firstSpec)
                 .WhenTrue((2, Metadata.True))
                 .WhenFalse((2, Metadata.False))
                 .Create("second all true");
-            
+
         var spec =
             Spec.Build(secondSpec)
                 .WhenTrue((3, Metadata.True))
@@ -110,11 +110,11 @@ public class HigherOrderMetadataSpecTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expected]);
     }
-    
+
     [Theory]
     [InlineData(true, true, true, Metadata.True)]
     [InlineData(true, true, false, Metadata.False)]
@@ -144,13 +144,13 @@ public class HigherOrderMetadataSpecTests
                 .WhenTrue((1, Metadata.Unknown))
                 .WhenFalse((1, Metadata.Unknown))
                 .Create("first all-true encapsulation");
-            
+
         var secondSpec =
             Spec.Build(firstSpec)
                 .WhenTrue((2, Metadata.Unknown))
                 .WhenFalse((2, Metadata.Unknown))
                 .Create("second all-true encapsulation");
-            
+
         var spec =
             Spec.Build(secondSpec)
                 .WhenTrue((3, Metadata.Unknown))
@@ -161,11 +161,11 @@ public class HigherOrderMetadataSpecTests
 
         // Act
         var act = result.RootMetadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expected]);
     }
-    
+
     [Theory]
     [InlineData(2, 4, 6, 8, true)]
     [InlineData(2, 4, 6, 9, false)]
@@ -173,14 +173,14 @@ public class HigherOrderMetadataSpecTests
     [InlineData(1, 3, 6, 9, false)]
     [InlineData(1, 3, 5, 9, false)]
     public void Should_allow_regular_true_yield_function_to_be_used_with_a_higher_order_yield_false_function(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         bool expected)
     {
         // Arrange
-        var underlyingSpec = 
+        var underlyingSpec =
             Spec.Build<int>(i => i % 2 == 0)
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
@@ -197,11 +197,11 @@ public class HigherOrderMetadataSpecTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expected);
     }
-    
+
     [Theory]
     [InlineData(2, 4, 6, 8, Metadata.True)]
     [InlineData(2, 4, 6, 9, Metadata.False)]
@@ -209,14 +209,14 @@ public class HigherOrderMetadataSpecTests
     [InlineData(1, 3, 6, 9, Metadata.False)]
     [InlineData(1, 3, 5, 9, Metadata.False)]
     public void Should_yield_assertions_when_regular_true_yield_functions_to_be_used_with_a_higher_order_yield_false_functions(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         Metadata expectedMetadata)
     {
         // Arrange
-        var underlyingSpec = 
+        var underlyingSpec =
             Spec.Build<int>(i => i % 2 == 0)
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
@@ -233,26 +233,26 @@ public class HigherOrderMetadataSpecTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expectedMetadata]);
     }
-    
+
     [Theory]
     [InlineData(2, 4, 6, 8, "is even")]
-    [InlineData(2, 4, 6, 9, "!is even")]
-    [InlineData(1, 4, 6, 9, "!is even")]
-    [InlineData(1, 3, 6, 9, "!is even")]
-    [InlineData(1, 3, 5, 9, "!is even")]
+    [InlineData(2, 4, 6, 9, "¬is even")]
+    [InlineData(1, 4, 6, 9, "¬is even")]
+    [InlineData(1, 3, 6, 9, "¬is even")]
+    [InlineData(1, 3, 5, 9, "¬is even")]
     public void Should_identify_the_causes_that_yield_metadata_of_the_same_type(
-        int first, 
-        int second, 
+        int first,
+        int second,
         int third,
         int fourth,
         string expectedMetadata)
     {
         // Arrange
-        var underlyingSpec = 
+        var underlyingSpec =
             Spec.Build<int>(i => i % 2 == 0)
                 .WhenTrue(Metadata.True)
                 .WhenFalse(Metadata.False)
@@ -269,7 +269,7 @@ public class HigherOrderMetadataSpecTests
 
         // Act
         var act = result.CausesWithMetadata;
-        
+
         // Assert
         act.Should().AllSatisfy(x => x.Reason.Should().Be(expectedMetadata));
     }

--- a/Motiv.Tests/MinimalPropositionTests.cs
+++ b/Motiv.Tests/MinimalPropositionTests.cs
@@ -8,57 +8,57 @@ public class MinimalPropositionTests
     public void Should_evaluate_a_minimal_proposition(bool model, bool expectedSatisfied)
     {
         // Arrange
-        var spec = 
+        var spec =
             Spec.Build((bool b) => b)
                 .Create("is true");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(expectedSatisfied);
     }
-    
+
     [Theory]
     [InlineData(true, "is true")]
-    [InlineData(false, "!is true")]
+    [InlineData(false, "¬is true")]
     public void Should_evaluate_reason_of_a_minimal_proposition(bool model, string expectedReason)
     {
         // Arrange
-        var spec = 
+        var spec =
             Spec.Build((bool b) => b)
                 .Create("is true");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "is true", "is true")]
-    [InlineData(false, "is true", "!is true")]
+    [InlineData(false, "is true", "¬is true")]
     [InlineData(true, "is true (with brackets)", "(is true (with brackets))")]
-    [InlineData(false, "is true (with brackets)", "!(is true (with brackets))")]
+    [InlineData(false, "is true (with brackets)", "¬(is true (with brackets))")]
     [InlineData(true, "is true!", "(is true!)")]
-    [InlineData(false, "is true!", "!(is true!)")]
+    [InlineData(false, "is true!", "¬(is true!)")]
     public void Should_escape_propositional_statement_when_evaluated(bool model, string propositionalStatement, string expectedReason)
     {
         // Arrange
-        var spec = 
+        var spec =
             Spec.Build((bool b) => b)
                 .Create(propositionalStatement);
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }

--- a/Motiv.Tests/NotSpecTests.cs
+++ b/Motiv.Tests/NotSpecTests.cs
@@ -50,16 +50,16 @@ public class NotSpecTests
     }
 
     [Theory]
-    [InlineAutoData(true, "is true")]
-    [InlineAutoData(false, "!is true")]
+    [InlineAutoData(true, "!is true")]
+    [InlineAutoData(false, "!¬is true")]
     public void Should_serialize_the_result_of_the_not_operation(
-        bool operand,
+        bool predicateResult,
         string expected,
         object model)
     {
         // Arrange
         var underlyingSpec = Spec
-            .Build<object>(_ => operand)
+            .Build<object>(_ => predicateResult)
             .WhenTrue(true)
             .WhenFalse(false)
             .Create("is true");
@@ -76,8 +76,8 @@ public class NotSpecTests
     }
 
     [Theory]
-    [InlineAutoData(true, "True")]
-    [InlineAutoData(false, "False")]
+    [InlineAutoData(true, "!True")]
+    [InlineAutoData(false, "!False")]
     public void Should_serialize_the_result_of_the_not_operation_when_metadata_is_a_string(
         bool operand,
         string expected,

--- a/Motiv.Tests/OrElseSpecTests.cs
+++ b/Motiv.Tests/OrElseSpecTests.cs
@@ -329,7 +329,7 @@ public class OrElseSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left", "!right")]
+    [InlineData(false, false, "¬left", "¬right")]
     [InlineData(false, true, "right")]
     [InlineData(true, false, "left")]
     [InlineData(true, true, "left")]
@@ -363,7 +363,7 @@ public class OrElseSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left", "!right")]
+    [InlineData(false, false, "¬left", "¬right")]
     [InlineData(false, true, "right")]
     [InlineData(true, false, "left")]
     [InlineData(true, true, "left")]
@@ -471,8 +471,8 @@ public class OrElseSpecTests
     [InlineData(false, false,
         """
         NOR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nor_creation(bool leftBool, bool rightBool, string expected)
     {
@@ -505,8 +505,8 @@ public class OrElseSpecTests
     [InlineData(false, false,
         """
         OR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nor_negation(bool leftBool, bool rightBool, string expected)
     {
@@ -539,8 +539,8 @@ public class OrElseSpecTests
     [InlineData(false, false,
         """
         NOR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nor_double_negation(bool leftBool, bool rightBool, string expected)
     {

--- a/Motiv.Tests/OrSpecTests.cs
+++ b/Motiv.Tests/OrSpecTests.cs
@@ -79,7 +79,7 @@ public class OrSpecTests
     [InlineAutoData(true, true, "left | right")]
     [InlineAutoData(true, false, "left")]
     [InlineAutoData(false, true, "right")]
-    [InlineAutoData(false, false, "!left | !right")]
+    [InlineAutoData(false, false, "¬left | ¬right")]
     public void Should_serialize_the_result_of_the_or_operation(
         bool leftResult,
         bool rightResult,
@@ -147,7 +147,7 @@ public class OrSpecTests
     [InlineAutoData(true, true, "left | right")]
     [InlineAutoData(true, false, "left")]
     [InlineAutoData(false, true, "right")]
-    [InlineAutoData(false, false, "!left | !right")]
+    [InlineAutoData(false, false, "¬left | ¬right")]
     public void Should_serialize_the_result_of_the_or_operation_when_metadata_is_a_string(
         bool leftResult,
         bool rightResult,
@@ -401,7 +401,7 @@ public class OrSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left", "!right")]
+    [InlineData(false, false, "¬left", "¬right")]
     [InlineData(false, true, "right")]
     [InlineData(true, false, "left")]
     [InlineData(true, true, "left", "right")]
@@ -435,7 +435,7 @@ public class OrSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left", "!right")]
+    [InlineData(false, false, "¬left", "¬right")]
     [InlineData(false, true, "right")]
     [InlineData(true, false, "left")]
     [InlineData(true, true, "left", "right")]
@@ -565,8 +565,8 @@ public class OrSpecTests
     [InlineData(false, false,
         """
         NOR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nor_creation(bool leftBool, bool rightBool, string expected)
     {
@@ -600,8 +600,8 @@ public class OrSpecTests
     [InlineData(false, false,
         """
         OR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nor_negation(bool leftBool, bool rightBool, string expected)
     {
@@ -635,8 +635,8 @@ public class OrSpecTests
     [InlineData(false, false,
         """
         NOR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_nor_double_negation(bool leftBool, bool rightBool, string expected)
     {

--- a/Motiv.Tests/PropositionResultDescriptionTests.cs
+++ b/Motiv.Tests/PropositionResultDescriptionTests.cs
@@ -46,7 +46,7 @@ public class PropositionResultDescriptionTests
 
     [Theory]
     [InlineAutoData(true, "is true")]
-    [InlineAutoData(false, "!is true")]
+    [InlineAutoData(false, "¬is true")]
     public void Should_generate_a_simple_description_using_proposition_when_metadata_is_not_a_string(
         bool isTrue,
         string expected,
@@ -69,10 +69,10 @@ public class PropositionResultDescriptionTests
     }
 
     [Theory]
-    [InlineAutoData(false, false, "!left | !right")]
-    [InlineAutoData(false, true, "!left & right")]
-    [InlineAutoData(true, false, "left & !right")]
-    [InlineAutoData(true, true, "right | left")]
+    [InlineAutoData(false, false, "¬left | ¬right")]
+    [InlineAutoData(false, true, "!¬left & right")]
+    [InlineAutoData(true, false, "left & !¬right")]
+    [InlineAutoData(true, true, "!right | !left")]
     public void Should_generate_a_description_from_a_composition(
         bool leftResult,
         bool rightResult,
@@ -100,19 +100,19 @@ public class PropositionResultDescriptionTests
     }
 
     [Theory]
-    [InlineAutoData(false, false, false, false, "(!first | !second) & (!third | !fourth)")]
-    [InlineAutoData(false, false, false, true,  "!first | !second")]
-    [InlineAutoData(false, false, true, false,  "!first | !second")]
-    [InlineAutoData(false, false, true, true,   "!first | !second")]
-    [InlineAutoData(false, true, false, false,  "!third | !fourth")]
+    [InlineAutoData(false, false, false, false, "(¬first | ¬second) & (¬third | ¬fourth)")]
+    [InlineAutoData(false, false, false, true,  "¬first | ¬second")]
+    [InlineAutoData(false, false, true, false,  "¬first | ¬second")]
+    [InlineAutoData(false, false, true, true,   "¬first | ¬second")]
+    [InlineAutoData(false, true, false, false,  "¬third | ¬fourth")]
     [InlineAutoData(false, true, false, true,   "second & fourth")]
     [InlineAutoData(false, true, true, false,   "second & third")]
     [InlineAutoData(false, true, true, true,    "second & (third | fourth)")]
-    [InlineAutoData(true, false, false, false,  "!third | !fourth")]
+    [InlineAutoData(true, false, false, false,  "¬third | ¬fourth")]
     [InlineAutoData(true, false, false, true,   "first & fourth")]
     [InlineAutoData(true, false, true, false,   "first & third")]
     [InlineAutoData(true, false, true, true,    "first & (third | fourth)")]
-    [InlineAutoData(true, true, false, false,   "!third | !fourth")]
+    [InlineAutoData(true, true, false, false,   "¬third | ¬fourth")]
     [InlineAutoData(true, true, false, true,    "(first | second) & fourth")]
     [InlineAutoData(true, true, true, false,    "(first | second) & third")]
     [InlineAutoData(true, true, true, true,     "(first | second) & (third | fourth)")]
@@ -219,43 +219,43 @@ public class PropositionResultDescriptionTests
         some are false
             AND
                 OR
-                    !first
-                    !second
+                    ¬first
+                    ¬second
                 OR
-                    !third
-                    !fourth
+                    ¬third
+                    ¬fourth
         """)]
     [InlineAutoData(false, false, false, true,
         """
         some are false
             AND
                 OR
-                    !first
-                    !second
+                    ¬first
+                    ¬second
         """)]
     [InlineAutoData(false, false, true, false,
         """
         some are false
             AND
                 OR
-                    !first
-                    !second
+                    ¬first
+                    ¬second
         """)]
     [InlineAutoData(false, false, true, true,
         """
         some are false
             AND
                 OR
-                    !first
-                    !second
+                    ¬first
+                    ¬second
         """)]
     [InlineAutoData(false, true, false, false,
         """
         some are false
             AND
                 OR
-                    !third
-                    !fourth
+                    ¬third
+                    ¬fourth
         """)]
     [InlineAutoData(false, true, false, true,
         """
@@ -290,8 +290,8 @@ public class PropositionResultDescriptionTests
         some are false
             AND
                 OR
-                    !third
-                    !fourth
+                    ¬third
+                    ¬fourth
         """)]
     [InlineAutoData(true, false, false, true,
         """
@@ -326,8 +326,8 @@ public class PropositionResultDescriptionTests
         some are false
             AND
                 OR
-                    !third
-                    !fourth
+                    ¬third
+                    ¬fourth
         """)]
     [InlineAutoData(true, true, false, true,
         """
@@ -406,15 +406,15 @@ public class PropositionResultDescriptionTests
         """
         AND
             NOR
-                !fourth
+                ¬fourth
         """)]
     [InlineAutoData(false, false, false, true,
         """
         AND
             OR
-                !second
+                ¬second
             NOR
-                !third
+                ¬third
                 fourth
         """)]
     [InlineAutoData(false, false, true, false,
@@ -422,7 +422,7 @@ public class PropositionResultDescriptionTests
         AND
             NOR
                 third
-                !fourth
+                ¬fourth
         """)]
     [InlineAutoData(false, false, true, true,
         """
@@ -434,33 +434,33 @@ public class PropositionResultDescriptionTests
         """
         AND
             OR
-                !first
+                ¬first
                 second
             NOR
-                !fourth
+                ¬fourth
         """)]
     [InlineAutoData(false, true, false, true,
         """
         AND
             OR
-                !first
+                ¬first
                 second
         """)]
     [InlineAutoData(false, true, true, false,
         """
         AND
             OR
-                !first
+                ¬first
                 second
             NOR
                 third
-                !fourth
+                ¬fourth
         """)]
     [InlineAutoData(false, true, true, true,
         """
         AND
             OR
-                !first
+                ¬first
                 second
             NOR
                 third
@@ -469,16 +469,16 @@ public class PropositionResultDescriptionTests
         """
         AND
             NOR
-                !fourth
+                ¬fourth
         """)]
     [InlineAutoData(true, false, false, true,
         """
         AND
             OR
                 first
-                !second
+                ¬second
             NOR
-                !third
+                ¬third
                 fourth
         """)]
     [InlineAutoData(true, false, true, false,
@@ -486,7 +486,7 @@ public class PropositionResultDescriptionTests
         AND
             NOR
                 third
-                !fourth
+                ¬fourth
         """)]
     [InlineAutoData(true, false, true, true,
         """
@@ -498,7 +498,7 @@ public class PropositionResultDescriptionTests
         """
         AND
             NOR
-                !fourth
+                ¬fourth
         """)]
     [InlineAutoData(true, true, false, true,
         """
@@ -506,7 +506,7 @@ public class PropositionResultDescriptionTests
             OR
                 first
             NOR
-                !third
+                ¬third
                 fourth
         """)]
     [InlineAutoData(true, true, true, false,
@@ -514,7 +514,7 @@ public class PropositionResultDescriptionTests
         AND
             NOR
                 third
-                !fourth
+                ¬fourth
         """)]
     [InlineAutoData(true, true, true, true,
         """
@@ -872,17 +872,127 @@ public class PropositionResultDescriptionTests
             """);
     }
 
-    [Fact]
-    public void Should_negate_a_binary_operation_results_that_contains_negated_proposition_statements()
+    [Theory]
+    [InlineData(true, true,"!(¬b | ¬c)", "¬b", "¬c")]
+    [InlineData(false, false,"!(b | c)", "b", "c")]
+    public void Should_negate_a_binary_operation_results_that_contains_negated_proposition_statements(
+        bool model,
+        bool expectedSatisfied,
+        string expectedReason,
+        params string[] expectedAssertions)
     {
-        var specA = Spec.Build((bool b) => b).Create("a");
         var specB = Spec.Build((bool b) => !b).Create("b");
         var specC = Spec.Build((bool b) => !b).Create("c");
 
-        var spec = specA & !(specB | specC);
+        var spec =  !(specB | specC);
 
-        var act = spec.IsSatisfiedBy(true);
+        var act = spec.IsSatisfiedBy(model);
 
-        act.Reason.Should().Be("a & !(!b | !c)");
+        act.Satisfied.Should().Be(expectedSatisfied);
+        act.Reason.Should().Be(expectedReason);
+        act.Assertions.Should().BeEquivalentTo(expectedAssertions);
     }
+
+    [Theory]
+    [InlineData(true, false, "!(!¬b | !¬c)", "¬b", "¬c")]
+    [InlineData(false, true, "!(!b | !c)", "b", "c")]
+    public void Should_negate_a_binary_operation_results_that_contains_single_negated_proposition_statements(
+        bool model,
+        bool expectedSatisfied,
+        string expectedReason,
+        params string[] expectedAssertions)
+    {
+        var specB = Spec.Build((bool b) => !b).Create("b");
+        var specC = Spec.Build((bool b) => !b).Create("c");
+
+        var spec = !(!specB | !specC);
+
+        var act = spec.IsSatisfiedBy(model);
+
+        act.Satisfied.Should().Be(expectedSatisfied);
+        act.Reason.Should().Be(expectedReason);
+        act.Assertions.Should().BeEquivalentTo(expectedAssertions);
+    }
+
+
+    [Theory]
+    [InlineData(true, true,"!(¬b | ¬c)", "¬b", "¬c")]
+    [InlineData(false,  false,"!(b | c)", "b", "c")]
+    public void Should_negate_a_binary_operation_results_that_contains_double_negated_proposition_statements(
+        bool model,
+        bool expectedSatisfied,
+        string expectedReason,
+        params string[] expectedAssertions)
+    {
+        var specB = Spec.Build((bool b) => !b).Create("b");
+        var specC = Spec.Build((bool b) => !b).Create("c");
+
+        var spec = !(!!specB | !!specC);
+
+        var act = spec.IsSatisfiedBy(model);
+
+        act.Satisfied.Should().Be(expectedSatisfied);
+        act.Reason.Should().Be(expectedReason);
+        act.Assertions.Should().BeEquivalentTo(expectedAssertions);
+    }
+
+    [Theory]
+    [InlineData(true, false, "!(!b | !c)", "b", "c")]
+    [InlineData(false, true, "!(!B | !C)", "B", "C")]
+    public void Should_negate_a_binary_operation_results_that_contains_single_negated_proposition_statements_with_assertions(
+        bool model,
+        bool expectedSatisfied,
+        string expectedReason,
+        params string[] expectedAssertions)
+    {
+        var specB =
+            Spec.Build((bool b) => !b)
+                .WhenTrue("B")
+                .WhenFalse("b")
+                .Create("is b");
+        var specC =
+            Spec.Build((bool b) => !b)
+                .WhenTrue("C")
+                .WhenFalse("c")
+                .Create("is c");
+
+        var spec = !(!specB | !specC);
+
+        var act = spec.IsSatisfiedBy(model);
+
+        act.Satisfied.Should().Be(expectedSatisfied);
+        act.Reason.Should().Be(expectedReason);
+        act.Assertions.Should().BeEquivalentTo(expectedAssertions);
+    }
+
+    [Theory]
+    [InlineData(true, true, "!(b | c)", "b", "c")]
+    [InlineData(false, false, "!(B | C)", "B", "C")]
+    public void Should_negate_a_binary_operation_results_that_contains_double_negated_proposition_statements_with_assertions(
+        bool model,
+        bool expectedSatisfied,
+        string expectedReason,
+        params string[] expectedAssertions)
+    {
+        var specB =
+            Spec.Build((bool b) => !b)
+                .WhenTrue("B")
+                .WhenFalse("b")
+                .Create("is b");
+        var specC =
+            Spec.Build((bool b) => !b)
+                .WhenTrue("C")
+                .WhenFalse("c")
+                .Create("is c");
+
+        var spec = !(!!specB | !!specC);
+
+        var act = spec.IsSatisfiedBy(model);
+
+        act.Satisfied.Should().Be(expectedSatisfied);
+        act.Reason.Should().Be(expectedReason);
+        act.Assertions.Should().BeEquivalentTo(expectedAssertions);
+    }
+
+
 }

--- a/Motiv.Tests/SpecDecoratorExplanationPropositionTests.cs
+++ b/Motiv.Tests/SpecDecoratorExplanationPropositionTests.cs
@@ -46,11 +46,11 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [InlineData(true, "true - A", "true + model - B", "true - C", "true + model - D")]
     [InlineData(false, "false - A", "false - B", "false + model - C", "false + model - D")]
     [Theory]
@@ -95,7 +95,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
@@ -154,7 +154,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectation);
     }
@@ -177,7 +177,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo("true");
     }
@@ -201,7 +201,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(model);
     }
@@ -227,7 +227,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo($"{model} - underlying true");
     }
@@ -255,7 +255,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo($"{model} - underlying true");
     }
@@ -279,7 +279,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo("false");
     }
@@ -303,7 +303,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(model);
     }
@@ -329,7 +329,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo($"{model} - underlying false");
     }
@@ -357,7 +357,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo($"{model} - underlying false");
     }
@@ -380,15 +380,14 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(model);
     }
-    
 
     [Theory]
     [InlineAutoData(true, "is true")]
-    [InlineAutoData(false, "!is true")]
+    [InlineAutoData(false, "¬is true")]
     public void Should_provide_a_reason_for_minimally_defined_spec(bool model, string expectedReason)
     {
         // Arrange
@@ -404,7 +403,7 @@ public class SpecDecoratorExplanationPropositionTests
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
@@ -418,178 +417,178 @@ public class SpecDecoratorExplanationPropositionTests
             .WhenTrue("left true")
             .WhenFalse("left false")
             .Create("left");
-        
+
         var right = Spec
             .Build<string>(_ => true)
             .WhenTrue("right true")
             .WhenFalse("right false")
             .Create("right");
-        
+
         var underlying = left | right;
-        
+
         var spec = Spec
             .Build(underlying)
             .Create("top-level proposition");
-        
+
         var result = spec.IsSatisfiedBy("model");
 
         // Act
         var act = result.Description.Reason;
-        
+
         // Assert
         act.Should().NotContainAny("left true", "left false", "right true", "right false");
-        
+
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_create_a_boolean_result_that_contains_the_underlying_result(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var expected = orSpec.IsSatisfiedBy(model);
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Underlying;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expected]);
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_create_a_boolean_result_that_contains_the_underlying_with_metadata_result(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var expected = orSpec.IsSatisfiedBy(model);
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.UnderlyingWithMetadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expected]);
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_have_a_description_that_has_a_causal_count_value_of_1(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Description.CausalOperandCount;
-        
+
         // Assert
         act.Should().Be(1);
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_create_a_boolean_result_that_contains_the_causal_result(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var expected = orSpec.IsSatisfiedBy(model).Causes;
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Causes;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_create_a_boolean_result_that_contains_the_causal_with_metadata_result(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var expected = orSpec.IsSatisfiedBy(model).CausesWithMetadata;
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.CausesWithMetadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
@@ -605,30 +604,30 @@ public class SpecDecoratorExplanationPropositionTests
             .WhenTrue("left true")
             .WhenFalse("left false")
             .Create();
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .WhenTrue("right true")
             .WhenFalse("right false")
             .Create();
-        
+
         var underlying = left ^ !right;
-        
+
         var spec = Spec
             .Build(underlying)
             .WhenTrueYield((satisfied, result) => result.Assertions.Select(assertion => $"{satisfied}: {assertion}"))
             .WhenFalseYield((satisfied, result) => result.Assertions.Select(assertion => $"{satisfied}: {assertion}"))
             .Create("top-level proposition");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedLeft, expectedRight);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion")]
     [InlineData(false, "false assertion")]
@@ -636,70 +635,70 @@ public class SpecDecoratorExplanationPropositionTests
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create();
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue("true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create();
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue("true assertion")
                 .WhenFalse((_, _) => "false assertion")
                 .Create();
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrue("true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue("true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue("true assertion")
@@ -709,19 +708,19 @@ public class SpecDecoratorExplanationPropositionTests
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_using_multiple_assertions(
             bool model,
             string expectedReason)
@@ -729,22 +728,22 @@ public class SpecDecoratorExplanationPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var spec =
             Spec.Build(underlying)
                 .WhenTrue("true assertion")
                 .WhenFalseYield((_, _) => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "true assertion")]
     [InlineData(false, "false assertion")]
@@ -752,25 +751,25 @@ public class SpecDecoratorExplanationPropositionTests
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue(_ => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue(_ => "true assertion")
@@ -780,19 +779,19 @@ public class SpecDecoratorExplanationPropositionTests
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
 
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void
         Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_single_parameter_callback_when_using_multiple_assertions(
             bool model,
@@ -801,18 +800,18 @@ public class SpecDecoratorExplanationPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var spec =
             Spec.Build(underlying)
                 .WhenTrue(_ => "true assertion")
                 .WhenFalseYield((_, _) => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
@@ -824,25 +823,25 @@ public class SpecDecoratorExplanationPropositionTests
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 3));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrue((_, _) => "true assertion")
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue((_, _) => "true assertion")
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue((_, _) => "true assertion")
@@ -852,19 +851,19 @@ public class SpecDecoratorExplanationPropositionTests
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void
         Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_when_using_multiple_assertions(
             bool model,
@@ -873,70 +872,70 @@ public class SpecDecoratorExplanationPropositionTests
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var spec =
             Spec.Build(underlying)
                 .WhenTrue((_, _) => "true assertion")
                 .WhenFalseYield((_, _) => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_that_returns_a_collection(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrueYield((_, _) => ["true assertion"])
                 .WhenFalse("false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrueYield((_, _) => ["true assertion"])
                 .WhenFalse(_ => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrueYield((_, _) => ["true assertion"])
                 .WhenFalse((_, _) => "false assertion")
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .WhenTrueYield((_, _) => ["true assertion"])
                 .WhenFalseYield((_, _) => ["false assertion"])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }

--- a/Motiv.Tests/SpecDecoratorMetadataPropositionTests.cs
+++ b/Motiv.Tests/SpecDecoratorMetadataPropositionTests.cs
@@ -7,10 +7,10 @@ public class SpecDecoratorMetadataPropositionTests
         True,
         False
     }
-    
+
     [Theory]
     [InlineData(true, "is first true", "is second true", "is third true", "is fourth true")]
-    [InlineData(false, "!is first true", "!is second true", "!is third true", "!is fourth true")]
+    [InlineData(false, "¬is first true", "¬is second true", "¬is third true", "¬is fourth true")]
     public void Should_replace_the_assertion_with_new_assertion(
         bool isSatisfied,
         params string[] expected)
@@ -52,11 +52,11 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [InlineData(true, 200, 300, 400, 500)]
     [InlineData(false, -200, -300, -400, -500)]
     [Theory]
@@ -105,7 +105,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectation);
     }
@@ -165,7 +165,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectation);
     }
@@ -188,7 +188,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([Metadata.True]);
     }
@@ -213,7 +213,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected.ToEnumerable());
     }
@@ -240,7 +240,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([(model, expected.ToEnumerable())]);
     }
@@ -268,7 +268,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo($"{model} - underlying true");
     }
@@ -294,7 +294,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([isTrueMetadata]);
     }
@@ -320,7 +320,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([guidModel]);
     }
@@ -350,7 +350,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([(guidModel, underlyingTrueGuid)]);
     }
@@ -381,7 +381,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([(guidModel, underlyingTrueGuid)]);
     }
@@ -404,7 +404,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo("false");
     }
@@ -428,7 +428,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(model);
     }
@@ -454,7 +454,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo($"{model} - underlying false");
     }
@@ -482,7 +482,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo($"{model} - underlying false");
     }
@@ -508,7 +508,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([isFalseMetadata]);
     }
@@ -534,7 +534,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([guidModel]);
     }
@@ -564,7 +564,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([(guidModel, underlyingFalseGuid)]);
     }
@@ -595,7 +595,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Metadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([(guidModel, underlyingFalseGuid)]);
     }
@@ -618,14 +618,14 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Satisfied;
-        
+
         // Assert
         act.Should().Be(model);
     }
-    
+
     [Theory]
     [InlineAutoData(true, "is true")]
-    [InlineAutoData(false, "!is true")]
+    [InlineAutoData(false, "¬is true")]
     public void Should_provide_a_reason_for_minimally_defined_spec(bool model, string expectedReason)
     {
         // Arrange
@@ -641,7 +641,7 @@ public class SpecDecoratorMetadataPropositionTests
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
@@ -655,178 +655,178 @@ public class SpecDecoratorMetadataPropositionTests
             .WhenTrue("left true")
             .WhenFalse("left false")
             .Create("left");
-        
+
         var right = Spec
             .Build<string>(_ => true)
             .WhenTrue("right true")
             .WhenFalse("right false")
             .Create("right");
-        
+
         var underlying = left | right;
-        
+
         var spec = Spec
             .Build(underlying)
             .Create("top-level proposition");
-        
+
         var result = spec.IsSatisfiedBy("model");
 
         // Act
         var act = result.Description.Reason;
-        
+
         // Assert
         act.Should().NotContainAny("left true", "left false", "right true", "right false");
-        
+
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_create_a_boolean_result_that_contains_the_underlying_result(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var expected = orSpec.IsSatisfiedBy(model);
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Underlying;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expected]);
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_create_a_boolean_result_that_contains_the_underlying_with_metadata_result(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var expected = orSpec.IsSatisfiedBy(model);
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.UnderlyingWithMetadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo([expected]);
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_have_a_description_that_has_a_causal_count_value_of_1(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Description.CausalOperandCount;
-        
+
         // Assert
         act.Should().Be(1);
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_create_a_boolean_result_that_contains_the_causal_result(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var expected = orSpec.IsSatisfiedBy(model).Causes;
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Causes;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
-    
+
     [Theory]
     [InlineAutoData(true)]
     [InlineAutoData(false)]
     public void Should_create_a_boolean_result_that_contains_the_causal_with_metadata_result(bool model)
     {
         // Arrange
-        var left = Spec 
+        var left = Spec
             .Build((bool m) => m)
             .Create("left");
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .Create("right");
 
         var orSpec = left | right;
-        
+
         var expected = orSpec.IsSatisfiedBy(model).CausesWithMetadata;
-        
+
         var spec = Spec
             .Build(orSpec)
             .Create("composite");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.CausesWithMetadata;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expected);
     }
@@ -842,234 +842,234 @@ public class SpecDecoratorMetadataPropositionTests
             .WhenTrue("left true")
             .WhenFalse("left false")
             .Create();
-        
+
         var right = Spec
             .Build((bool m) => !m)
             .WhenTrue("right true")
             .WhenFalse("right false")
             .Create();
-        
+
         var underlying = left ^ !right;
-        
+
         var spec = Spec
             .Build(underlying)
             .WhenTrueYield((satisfied, result) => result.Assertions.Select(assertion => $"{satisfied}: {assertion}"))
             .WhenFalseYield((satisfied, result) => result.Assertions.Select(assertion => $"{satisfied}: {assertion}"))
             .Create("top-level proposition");
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Assertions;
-        
+
         // Assert
         act.Should().BeEquivalentTo(expectedLeft, expectedRight);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrue(Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue(Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue(Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .WhenTrue(Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_single_parameter_callback(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .WhenTrue(_ => Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .WhenTrue((_, _) => Metadata.True)
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }
-    
+
     [Theory]
     [InlineData(true, "propositional statement")]
-    [InlineData(false, "!propositional statement")]
+    [InlineData(false, "¬propositional statement")]
     public void Should_use_the_propositional_statement_in_the_reason_when_true_assertion_uses_a_two_parameter_callback_that_returns_a_collection(
         bool model,
         string expectedReasonStatement)
     {
-        // Arrange 
+        // Arrange
         var expectedReason = string.Join(" & ", Enumerable.Repeat(expectedReasonStatement, 4));
-        
+
         var underlying =
             Spec.Build((bool m) => m)
                 .Create("is underlying true");
-        
+
         var withFalseAsScalar =
             Spec.Build(underlying)
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse(Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsParameterCallback =
             Spec.Build(underlying)
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse(_ => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallback =
             Spec.Build(underlying)
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalse((_, _) => Metadata.False)
                 .Create("propositional statement");
-        
+
         var withFalseAsTwoParameterCallbackThatReturnsACollection =
             Spec.Build(underlying)
                 .WhenTrueYield((_, _) => Metadata.True.ToEnumerable())
                 .WhenFalseYield((_, _) => [Metadata.False])
                 .Create("propositional statement");
-        
+
         var spec = withFalseAsScalar &
                    withFalseAsParameterCallback &
                    withFalseAsTwoParameterCallback &
                    withFalseAsTwoParameterCallbackThatReturnsACollection;
-        
+
         var result = spec.IsSatisfiedBy(model);
 
         // Act
         var act = result.Reason;
-        
+
         // Assert
         act.Should().Be(expectedReason);
     }

--- a/Motiv.Tests/SpecTests.cs
+++ b/Motiv.Tests/SpecTests.cs
@@ -186,7 +186,7 @@ public class SpecTests
 
     [Theory]
     [InlineAutoData(true, "is true")]
-    [InlineAutoData(false, "!is true")]
+    [InlineAutoData(false, "¬is true")]
     public void Should_return_a_result_that_explains_the_result(bool model,string expectedDescription)
     {
         // Arrange

--- a/Motiv.Tests/TutorialTests.cs
+++ b/Motiv.Tests/TutorialTests.cs
@@ -14,8 +14,8 @@ public class TutorialTests
         isEven.IsSatisfiedBy(2).Assertions.Should().BeEquivalentTo("is even");
 
         isEven.IsSatisfiedBy(3).Satisfied.Should().BeFalse();
-        isEven.IsSatisfiedBy(3).Reason.Should().BeEquivalentTo("!is even");
-        isEven.IsSatisfiedBy(3).Assertions.Should().BeEquivalentTo("!is even");
+        isEven.IsSatisfiedBy(3).Reason.Should().BeEquivalentTo("¬is even");
+        isEven.IsSatisfiedBy(3).Assertions.Should().BeEquivalentTo("¬is even");
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public class TutorialTests
         var result = showShippingPageButton.IsSatisfiedBy(emptyBasket);
 
         result.Satisfied.Should().BeFalse();
-        result.Reason.Should().Be("basket is empty");
+        result.Reason.Should().Be("!basket is empty");
     }
 
     private class IsNegativeIntegerProposition() : Spec<int>(
@@ -370,7 +370,7 @@ public class TutorialTests
         var canCheckIn = canCheckInSpec.IsSatisfiedBy(validPassenger);
 
         canCheckIn.Satisfied.Should().Be(true);
-        canCheckIn.Reason.Should().BeEquivalentTo("has a valid ticket & does not have outstanding fees & check-in is open");
+        canCheckIn.Reason.Should().BeEquivalentTo("has a valid ticket & !does not have outstanding fees & check-in is open");
         canCheckIn.Assertions.Should().BeEquivalentTo("has a valid ticket", "does not have outstanding fees", "check-in is open");
     }
 
@@ -407,7 +407,7 @@ public class TutorialTests
 
         act.Justification.Should().Be(
             """
-            !customer is eligible for a loan
+            ¬customer is eligible for a loan
                 AND
                     customer has an inadequate credit score
                     customer has insufficient income
@@ -538,15 +538,15 @@ public class TutorialTests
         var result = isPartiallyFull.IsSatisfiedBy(5);
 
         result.Satisfied.Should().BeTrue();
-        result.Assertions.Should().BeEquivalentTo(["valid", "!empty", "!full"]);
-        result.Reason.Should().Be("valid & !(!empty | !full)");
+        result.Assertions.Should().BeEquivalentTo(["valid", "¬empty", "¬full"]);
+        result.Reason.Should().Be("valid & !(¬empty | ¬full)");
         result.Justification.Should().Be(
             """
             AND
                 valid
                 NOR
-                    !empty
-                    !full
+                    ¬empty
+                    ¬full
             """);
     }
 
@@ -578,7 +578,7 @@ public class TutorialTests
                 .WhenFalse("none")
                 .Create("xor");
 
-        spec.IsSatisfiedBy(true).Assertions.Should().BeEquivalentTo("!right");
-        spec.IsSatisfiedBy(false).Assertions.Should().BeEquivalentTo("!left");
+        spec.IsSatisfiedBy(true).Assertions.Should().BeEquivalentTo("¬right");
+        spec.IsSatisfiedBy(false).Assertions.Should().BeEquivalentTo("¬left");
     }
 }

--- a/Motiv.Tests/XOrSpecTests.cs
+++ b/Motiv.Tests/XOrSpecTests.cs
@@ -77,9 +77,9 @@ public class XOrSpecTests
 
     [Theory]
     [InlineAutoData(true, true, "left ^ right")]
-    [InlineAutoData(true, false, "left ^ !right")]
-    [InlineAutoData(false, true, "!left ^ right")]
-    [InlineAutoData(false, false, "!left ^ !right")]
+    [InlineAutoData(true, false, "left ^ ¬right")]
+    [InlineAutoData(false, true, "¬left ^ right")]
+    [InlineAutoData(false, false, "¬left ^ ¬right")]
     public void Should_serialize_the_result_of_the_xor_operation(
         bool leftResult,
         bool rightResult,
@@ -412,9 +412,9 @@ public class XOrSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left", "!right")]
-    [InlineData(false, true, "!left", "right")]
-    [InlineData(true, false, "left", "!right")]
+    [InlineData(false, false, "¬left", "¬right")]
+    [InlineData(false, true, "¬left", "right")]
+    [InlineData(true, false, "left", "¬right")]
     [InlineData(true, true, "left", "right")]
     public void Should_perform_OrElse_on_specs_with_different_metadata_and_preserve_assertions(
         bool leftValue,
@@ -446,9 +446,9 @@ public class XOrSpecTests
     }
 
     [Theory]
-    [InlineData(false, false, "!left", "!right")]
-    [InlineData(false, true, "!left", "right")]
-    [InlineData(true, false, "left", "!right")]
+    [InlineData(false, false, "¬left", "¬right")]
+    [InlineData(false, true, "¬left", "right")]
+    [InlineData(true, false, "left", "¬right")]
     [InlineData(true, true, "left", "right")]
     public void Should_yield_metadata_as_a_string_when_specs_containing_different_metadata_types_are_composed(
         bool leftValue,
@@ -634,20 +634,21 @@ public class XOrSpecTests
         """
         XNOR
             left
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         XNOR
-            !left
+            ¬left
             right
         """)]
     [InlineData(false, false,
         """
         XNOR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
+
     public void Should_justify_a_xnor_creation(bool leftBool, bool rightBool, string expected)
     {
         var left = Spec.Build((bool _) => leftBool).Create("left");
@@ -671,19 +672,19 @@ public class XOrSpecTests
         """
         XOR
             left
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         XOR
-            !left
+            ¬left
             right
         """)]
     [InlineData(false, false,
         """
         XOR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_xnor_negation(bool leftBool, bool rightBool, string expected)
     {
@@ -708,19 +709,19 @@ public class XOrSpecTests
         """
         XNOR
             left
-            !right
+            ¬right
         """)]
     [InlineData(false, true,
         """
         XNOR
-            !left
+            ¬left
             right
         """)]
     [InlineData(false, false,
         """
         XNOR
-            !left
-            !right
+            ¬left
+            ¬right
         """)]
     public void Should_justify_a_xnor_double_negation(bool leftBool, bool rightBool, string expected)
     {

--- a/Motiv/BooleanPredicateProposition/ExplanationProposition.cs
+++ b/Motiv/BooleanPredicateProposition/ExplanationProposition.cs
@@ -8,9 +8,7 @@ internal sealed class ExplanationProposition<TModel>(
     : SpecBase<TModel, string>
 {
 
-    private const char Not = '\u00ac'; /* ¬ */
-
-    public override IEnumerable<SpecBase> Underlying => Enumerable.Empty<SpecBase>();
+    public override IEnumerable<SpecBase> Underlying => [];
 
     internal ExplanationProposition(Func<TModel, bool> predicate, ISpecDescription specDescription)
         : this(
@@ -63,7 +61,7 @@ internal sealed class ExplanationProposition<TModel>(
         {
             (true, true) => $"({proposition})",
             (true, _)=> proposition,
-            (false, true) => $"{Not}({proposition})",
-            (false, _) => $"{Not}{proposition}"
+            (false, true) => $"¬({proposition})",
+            (false, _) => $"¬{proposition}"
         };
 }

--- a/Motiv/BooleanPredicateProposition/ExplanationProposition.cs
+++ b/Motiv/BooleanPredicateProposition/ExplanationProposition.cs
@@ -7,17 +7,20 @@ internal sealed class ExplanationProposition<TModel>(
     ISpecDescription specDescription)
     : SpecBase<TModel, string>
 {
+
+    private const char Not = '\u00ac'; /* ¬ */
+
     public override IEnumerable<SpecBase> Underlying => Enumerable.Empty<SpecBase>();
-    
-    internal ExplanationProposition(Func<TModel, bool> predicate, ISpecDescription specDescription) 
+
+    internal ExplanationProposition(Func<TModel, bool> predicate, ISpecDescription specDescription)
         : this(
-            predicate, 
-            _ => ReasonFromPropositionStatement(true, specDescription.Statement), 
-            _ => ReasonFromPropositionStatement(false, specDescription.Statement), 
+            predicate,
+            _ => ReasonFromPropositionStatement(true, specDescription.Statement),
+            _ => ReasonFromPropositionStatement(false, specDescription.Statement),
             specDescription)
     {
     }
-    
+
     public override ISpecDescription Description => specDescription;
 
     public override BooleanResultBase<string> IsSatisfiedBy(TModel model)
@@ -54,13 +57,13 @@ internal sealed class ExplanationProposition<TModel>(
             this,
             () => falseBecause(model),
             nameof(falseBecause));
-    
+
     private static string ReasonFromPropositionStatement(bool isSatisfied, string proposition) =>
         (isSatisfied, proposition.ContainsReservedCharacters()) switch
         {
             (true, true) => $"({proposition})",
             (true, _)=> proposition,
-            (false, true) => $"!({proposition})",
-            (false, _) => $"!{proposition}"
+            (false, true) => $"{Not}({proposition})",
+            (false, _) => $"{Not}{proposition}"
         };
 }

--- a/Motiv/HigherOrderProposition/PropositionBuilders/TrueHigherOrderFromBooleanPredicatePropositionBuilder.cs
+++ b/Motiv/HigherOrderProposition/PropositionBuilders/TrueHigherOrderFromBooleanPredicatePropositionBuilder.cs
@@ -14,8 +14,6 @@ public readonly ref struct TrueHigherOrderFromBooleanPredicatePropositionBuilder
     Func<IEnumerable<ModelResult<TModel>>, bool> higherOrderPredicate,
     Func<bool, IEnumerable<ModelResult<TModel>>, IEnumerable<ModelResult<TModel>>> causeSelector)
 {
-    private const char Not = '\u00ac'; /* ¬ */
-
     /// <summary>Specifies the metadata to use when the condition is true.</summary>
     /// <typeparam name="TMetadata">The type of the metadata to use when the condition is true.</typeparam>
     /// <param name="whenTrue">The metadata to use when the condition is true.</param>
@@ -102,7 +100,7 @@ public readonly ref struct TrueHigherOrderFromBooleanPredicatePropositionBuilder
             predicate,
             higherOrderPredicate,
             _ => statement.ToEnumerable(),
-            _ => $"{Not}{statement}".ToEnumerable(),
+            _ => $"¬{statement}".ToEnumerable(),
             new SpecDescription(statement),
             causeSelector);
     }

--- a/Motiv/HigherOrderProposition/PropositionBuilders/TrueHigherOrderFromBooleanPredicatePropositionBuilder.cs
+++ b/Motiv/HigherOrderProposition/PropositionBuilders/TrueHigherOrderFromBooleanPredicatePropositionBuilder.cs
@@ -14,6 +14,8 @@ public readonly ref struct TrueHigherOrderFromBooleanPredicatePropositionBuilder
     Func<IEnumerable<ModelResult<TModel>>, bool> higherOrderPredicate,
     Func<bool, IEnumerable<ModelResult<TModel>>, IEnumerable<ModelResult<TModel>>> causeSelector)
 {
+    private const char Not = '\u00ac'; /* ¬ */
+
     /// <summary>Specifies the metadata to use when the condition is true.</summary>
     /// <typeparam name="TMetadata">The type of the metadata to use when the condition is true.</typeparam>
     /// <param name="whenTrue">The metadata to use when the condition is true.</param>
@@ -21,7 +23,7 @@ public readonly ref struct TrueHigherOrderFromBooleanPredicatePropositionBuilder
     public FalseMetadataFromBooleanHigherOrderPropositionBuilder<TModel, TMetadata> WhenTrue<TMetadata>(
         TMetadata whenTrue) =>
         new(predicate,
-            higherOrderPredicate, 
+            higherOrderPredicate,
             _ => whenTrue.ToEnumerable(),
             causeSelector);
 
@@ -41,8 +43,8 @@ public readonly ref struct TrueHigherOrderFromBooleanPredicatePropositionBuilder
             higherOrderPredicate,
             whenTrue.ToEnumerableReturn(),
             causeSelector);
-    
-    
+
+
     /// <summary>Specifies a metadata factory function to use when the condition is true.</summary>
     /// <typeparam name="TMetadata">The type of the metadata to use when the condition is true.</typeparam>
     /// <param name="whenTrue">A function that generates a collection of metadata when the condition is true.</param>
@@ -53,7 +55,7 @@ public readonly ref struct TrueHigherOrderFromBooleanPredicatePropositionBuilder
             higherOrderPredicate,
             whenTrue,
             causeSelector);
-    
+
     /// <summary>
     /// Specifies an assertion to yield when the condition is true.  This will also be the name of the proposition, unless otherwise
     /// specified by the subsequent <c>Create(string statement)</c> method.
@@ -88,7 +90,7 @@ public readonly ref struct TrueHigherOrderFromBooleanPredicatePropositionBuilder
             higherOrderPredicate,
             trueBecause,
             causeSelector);
-    
+
     /// <summary>Creates a proposition and names it with the propositional statement provided.</summary>
     /// <param name="statement">The proposition statement of what the specification represents.</param>
     /// <remarks>It is best to use short phases in natural-language, as if you were naming a boolean variable.</remarks>
@@ -100,7 +102,7 @@ public readonly ref struct TrueHigherOrderFromBooleanPredicatePropositionBuilder
             predicate,
             higherOrderPredicate,
             _ => statement.ToEnumerable(),
-            _ => $"!{statement}".ToEnumerable(),
+            _ => $"{Not}{statement}".ToEnumerable(),
             new SpecDescription(statement),
             causeSelector);
     }

--- a/Motiv/Motiv.csproj
+++ b/Motiv/Motiv.csproj
@@ -20,7 +20,7 @@
         <PackageTags>SpecificationPattern, DecisionMaking, Explanations, DesignPatterns, RulesEngine, BusinessLogic, Compliance, AuditTrails, RiskManagement, CSharp, .NET,  Developers, Architects, ProductManagement, Advanced, Intermediate, Propositions</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>7.2.0</Version>
+        <Version>7.3.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Motiv/Not/NotBooleanResultDescription.cs
+++ b/Motiv/Not/NotBooleanResultDescription.cs
@@ -29,13 +29,13 @@ internal sealed class NotBooleanResultDescription<TMetadata>(BooleanResultBase o
             yield return line;
     }
 
-    private string FormatReason(BooleanResultBase result)
+    private static string FormatReason(BooleanResultBase result)
     {
         return result switch
         {
             NotBooleanResult<TMetadata> notResult => NegateNotOperator(notResult),
             IBooleanOperationResult =>  $"!({result.Reason})",
-            _ =>$"{result.Reason}"
+            _ =>$"!{result.Reason}"
         };
     }
 
@@ -48,8 +48,6 @@ internal sealed class NotBooleanResultDescription<TMetadata>(BooleanResultBase o
             count++;
             current = nested;
         }
-
-
 
         return (count % 2 == 0, current.Operand) switch
         {

--- a/Motiv/PropositionExtensions.cs
+++ b/Motiv/PropositionExtensions.cs
@@ -13,10 +13,10 @@ internal static class PropositionExtensions
     {
         return isSatisfied switch
         {
-            true when PropositionContains('!') => $"({propositionStatement})",
+            true when PropositionContains('¬') => $"({propositionStatement})",
             true => propositionStatement,
-            false when PropositionContains('!') => $"!({propositionStatement})",
-            false => $"!{propositionStatement}"
+            false when PropositionContains('¬') => $"¬({propositionStatement})",
+            false => $"¬{propositionStatement}"
         };
 
         bool PropositionContains(char ch) => propositionStatement.Contains(ch);

--- a/Motiv/StringExtensions.cs
+++ b/Motiv/StringExtensions.cs
@@ -5,7 +5,9 @@ namespace Motiv;
 /// </summary>
 public static class StringExtensions
 {
-    private static readonly HashSet<char> Characters = ['!', '(', ')', '&', '|', '^'];
+    private const char Not = '\u00ac'; /* ¬ */
+
+    private static readonly HashSet<char> Characters = ['!', '(', ')', '&', '|', '^', Not ];
 
     /// <summary>
     /// Serializes a collection to a human-readable string.  It will separate the items with <c>", "</c> and the last
@@ -51,7 +53,7 @@ public static class StringExtensions
             yield return delimiter;
             yield return " ";
         }
-        
+
         switch (size)
         {
             case 0:

--- a/Motiv/StringExtensions.cs
+++ b/Motiv/StringExtensions.cs
@@ -5,9 +5,7 @@ namespace Motiv;
 /// </summary>
 public static class StringExtensions
 {
-    private const char Not = '\u00ac'; /* ¬ */
-
-    private static readonly HashSet<char> Characters = ['!', '(', ')', '&', '|', '^', Not ];
+    private static readonly HashSet<char> Characters = ['!', '(', ')', '&', '|', '^', '¬' ];
 
     /// <summary>
     /// Serializes a collection to a human-readable string.  It will separate the items with <c>", "</c> and the last

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ result.Justifications // partial
                       //     AND
                       //         valid
                       //         NOR
-                      //             !empty
-                      //             !full
+                      //             ¬empty
+                      //             ¬full
 ```
 
 ## Why Use Motiv?

--- a/docs/collections/results/GetFalseAssertions.md
+++ b/docs/collections/results/GetFalseAssertions.md
@@ -8,16 +8,16 @@ The `GetFalseAssertions()` extension method is used to extract the assertions fr
 that are not satisfied.
 
 ```csharp
-var left = Spec.Build((bool b) => b).Create("left");
-var right = Spec.Build((bool b) => !b).Create("right");    
+var left  = Spec.Build((bool b) => b).Create("left");
+var right = Spec.Build((bool b) => !b).Create("right");
 
 // XOR always considers both operands as causes, regardless of their results
 var spec =
      Spec .Build(left ^ right)
-              .WhenTrueYield((_, result) => result.Causes.GetFalseAssertions())
-              .WhenFalse("none")
-              .Create("xor");
+          .WhenTrueYield((_, result) => result.Causes.GetFalseAssertions())
+          .WhenFalse("none")
+          .Create("xor");
 
-spec.IsSatisfiedBy(true).Assertions;  // ["!right"]
-spec.IsSatisfiedBy(false).Assertions;  // ["!left"]
+spec.IsSatisfiedBy(true).Assertions;  // ["¬right"]
+spec.IsSatisfiedBy(false).Assertions;  // ["¬left"]
 ```

--- a/examples/Motiv.Poker.Tests/HandTests.cs
+++ b/examples/Motiv.Poker.Tests/HandTests.cs
@@ -189,15 +189,15 @@ public class HandTests
     [InlineData("AH, AD, AS, 10H, 9D", true, HandRank.ThreeOfAKind, "is a three of a kind hand")]
     [InlineData("AH, AD, QS, 10D, 10H", true, HandRank.TwoPair, "is a two pair hand")]
     [InlineData("AH, AD, 10S, 5C, 2H", true, HandRank.Pair, "is a pair hand")]
-    [InlineData("AH, 10D, 8S, 5C, 3D", false, HandRank.HighCard, "!is a royal flush hand",
-                                                                                            "!is a straight flush hand",
-                                                                                            "!is a four of a kind hand",
-                                                                                            "!is a full house hand",
-                                                                                            "!is a flush hand",
-                                                                                            "!is a straight hand",
-                                                                                            "!is a three of a kind hand",
-                                                                                            "!is a two pair hand",
-                                                                                            "!is a pair hand")]
+    [InlineData("AH, 10D, 8S, 5C, 3D", false, HandRank.HighCard, "¬is a royal flush hand",
+                                                                                            "¬is a straight flush hand",
+                                                                                            "¬is a four of a kind hand",
+                                                                                            "¬is a full house hand",
+                                                                                            "¬is a flush hand",
+                                                                                            "¬is a straight hand",
+                                                                                            "¬is a three of a kind hand",
+                                                                                            "¬is a two pair hand",
+                                                                                            "¬is a pair hand")]
     public void Should_evaluate_a_winning_hand(string handRanks, bool expected, HandRank expectedRank, params string[] expectedAssertion)
     {
         var cards = handRanks

--- a/index.md
+++ b/index.md
@@ -33,8 +33,8 @@ To get detailed feedback:
 var result = isPartiallyFull.IsSatisfiedBy(5);
 
 result.Satisfied;   // true
-result.Assertions;  // ["valid", "!empty", "!full"]
-result.Reason;      // "valid & !(!empty | !full)"
+result.Assertions;  // ["valid", "¬empty", "¬full"]
+result.Reason;      // "valid & !(¬empty | ¬full)"
 ```
 
 ## Installation

--- a/tutorial/BooleanResultVisibility.md
+++ b/tutorial/BooleanResultVisibility.md
@@ -15,14 +15,13 @@ var spec = specA & !(specB | specC);
 
 var act = spec.IsSatisfiedBy(true);
 
-act.Reason; // "a & (!b | !c)"
+act.Reason; // "a & !(¬b | ¬c)"
 ```
 
 The operators used in the `Reason` property are there to indicate how the propositions are combined.
-You will notice that the `!` symbol is only used to indicate that a proposition resolved to false, and is not used
-indicate that the original sub-expression was negated.
-Presenting the expression in this way allows you to quickly understand the structure of underlying causes instead of
-the structure of the original proposition.
+You will notice that the `¬` symbol is used to indicate that a proposition resolved to false, and is not used
+indicate that the original sub-expression was negated, which instead uses the `!` symbol.
+Presenting the expression in this way allows you to quickly identify a negative-assertion from a NOT operator.
 
 ### Justification
 

--- a/tutorial/MinimalProposition.md
+++ b/tutorial/MinimalProposition.md
@@ -18,8 +18,8 @@ And when negated:
 ```csharp
 var result = isEven.IsSatisfiedBy(3);
 
-result.Reason;    // "!is even"
-result.Assertion; // ["!is even"]
+result.Reason;    // "¬is even"
+result.Assertion; // ["¬is even"]
 ```
 
 It will implicitly create a `WhenTrue()` and `WhenFalse()` method, using as assertions the propositional statement
@@ -37,6 +37,6 @@ This is functionally the same as:
 ```csharp
 Spec.Build((int n) => n % 2 == 0)   // predicate
     .WhenTrue("is even")            // propositional statement
-    .WhenFalse("!is even")          // negation of the propositional statement
+    .WhenFalse("¬is even")          // negation of the propositional statement
     .Create();
 ```

--- a/tutorial/PropositionVisibility.md
+++ b/tutorial/PropositionVisibility.md
@@ -2,7 +2,7 @@
 
 ### Statement
 
-The `Statement` property will provide a simplified high-level representation of the proposition, while the 
+The `Statement` property will provide a simplified high-level representation of the proposition, while the
 `Expression` will go into more detail about the structure.
 
 ```csharp
@@ -12,7 +12,7 @@ var specC = Spec.Build((bool b) => !b).Create("c");
 
 var spec = specA & !(specB | specC);
 
-spec.Statement; // "a & !(b | c)"
+spec.Statement; // "a & !(¬b | ¬c)"
 ```
 
 ### Expression
@@ -20,7 +20,7 @@ spec.Statement; // "a & !(b | c)"
 Sometimes, this is not enough, and you need to understand the proposition in more detail.
 When building complicated expressions made up of many layers of encapsulated propositions, it can be challenging
 to understand the overall expression.
-While this problem exists regardless of how you decompose your logic, Motiv tries to mitigate this by allowing you to 
+While this problem exists regardless of how you decompose your logic, Motiv tries to mitigate this by allowing you to
 inspect (at runtime) the proposition before it is used to evaluate models.
 
 The `Expression` property will provide a detailed breakdown of the proposition, including encapsulated propositions with


### PR DESCRIPTION
## Description
Changed the symbol used to create negative-assertions from propositional-statements.  For instance: if a propositional statement was _is even_ and a negative assertion was generated from it as _!is even_, then after this change it would instead generate _¬is even_.

Fixes  #47 prevent negation ambiguity with the ! symbol

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Unit tests

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes