### PR TITLE
support genericless pattern matching on boolean-operator interfaces

### DIFF
--- a/Motiv/And/AndSpec.cs
+++ b/Motiv/And/AndSpec.cs
@@ -3,7 +3,10 @@ namespace Motiv.And;
 internal sealed class AndSpec<TModel, TMetadata>(
     SpecBase<TModel, TMetadata> left,
     SpecBase<TModel, TMetadata> right)
-    : SpecBase<TModel, TMetadata>, IBinaryOperationSpec<TModel, TMetadata>, IBinaryOperationSpec<TModel>
+    : SpecBase<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel>,
+        IBinaryOperationSpec
 {
     public override IEnumerable<SpecBase> Underlying => left.ToEnumerable().Append(right);
 
@@ -21,6 +24,10 @@ internal sealed class AndSpec<TModel, TMetadata>(
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Right => Right;
 
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Left => Left;
+
+    SpecBase IBinaryOperationSpec.Right => Right;
+
+    SpecBase IBinaryOperationSpec.Left => Left;
 
     protected override BooleanResultBase<TMetadata> IsSpecSatisfiedBy(TModel model)
     {

--- a/Motiv/AndAlso/AndAlsoSpec.cs
+++ b/Motiv/AndAlso/AndAlsoSpec.cs
@@ -3,7 +3,10 @@ namespace Motiv.AndAlso;
 internal sealed class AndAlsoSpec<TModel, TMetadata>(
     SpecBase<TModel, TMetadata> left,
     SpecBase<TModel, TMetadata> right)
-    : SpecBase<TModel, TMetadata>, IBinaryOperationSpec<TModel, TMetadata>, IBinaryOperationSpec<TModel>
+    : SpecBase<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel>,
+        IBinaryOperationSpec
 {
     public override IEnumerable<SpecBase> Underlying => left.ToEnumerable().Append(right);
 
@@ -33,4 +36,8 @@ internal sealed class AndAlsoSpec<TModel, TMetadata>(
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Right => Right;
 
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Left => Left;
+
+    SpecBase IBinaryOperationSpec.Right => Right;
+
+    SpecBase IBinaryOperationSpec.Left => Left;
 }

--- a/Motiv/IBinaryOperationSpec.cs
+++ b/Motiv/IBinaryOperationSpec.cs
@@ -6,6 +6,25 @@ namespace Motiv;
 /// <typeparam name="TModel">
 /// The type of the model.
 /// </typeparam>
+public interface IBinaryOperationSpec : IBooleanOperationSpec
+{
+    /// <summary>
+    /// The left side of the binary operation.
+    /// </summary>
+    SpecBase Left { get; }
+
+    /// <summary>
+    /// The right side of the binary operation.
+    /// </summary>
+    SpecBase Right { get; }
+}
+
+/// <summary>
+/// Represents a binary operation specification.
+/// </summary>
+/// <typeparam name="TModel">
+/// The type of the model.
+/// </typeparam>
 public interface IBinaryOperationSpec<TModel> : IBooleanOperationSpec
 {
     /// <summary>

--- a/Motiv/IUnaryOperationSpec.cs
+++ b/Motiv/IUnaryOperationSpec.cs
@@ -7,6 +7,20 @@ namespace Motiv;
 /// <typeparam name="TModel">
 /// The type of the model.
 /// </typeparam>
+public interface IUnaryOperationSpec : IBooleanOperationSpec
+{
+    /// <summary>
+    /// The underlying operand.
+    /// </summary>
+    SpecBase Operand { get; }
+}
+
+/// <summary>
+/// Represents a binary operation specification.
+/// </summary>
+/// <typeparam name="TModel">
+/// The type of the model.
+/// </typeparam>
 public interface IUnaryOperationSpec<TModel> : IBooleanOperationSpec
 {
     /// <summary>

--- a/Motiv/Motiv.csproj
+++ b/Motiv/Motiv.csproj
@@ -20,7 +20,7 @@
         <PackageTags>SpecificationPattern, DecisionMaking, Explanations, DesignPatterns, RulesEngine, BusinessLogic, Compliance, AuditTrails, RiskManagement, CSharp, .NET,  Developers, Architects, ProductManagement, Advanced, Intermediate, Propositions</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>7.4.2</Version>
+        <Version>7.4.3</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Motiv/Not/NotPolicy.cs
+++ b/Motiv/Not/NotPolicy.cs
@@ -2,7 +2,10 @@
 
 internal sealed class NotPolicy<TModel, TMetadata>(
     PolicyBase<TModel, TMetadata> operand)
-    : PolicyBase<TModel, TMetadata>, IUnaryOperationSpec<TModel, TMetadata>, IUnaryOperationSpec<TModel>
+    : PolicyBase<TModel, TMetadata>,
+        IUnaryOperationSpec<TModel, TMetadata>,
+        IUnaryOperationSpec<TModel>,
+        IUnaryOperationSpec
 {
     public override IEnumerable<SpecBase> Underlying => operand.ToEnumerable();
 
@@ -16,7 +19,9 @@ internal sealed class NotPolicy<TModel, TMetadata>(
     protected override PolicyResultBase<TMetadata> IsPolicySatisfiedBy(TModel model) =>
         operand.IsSatisfiedBy(model).Not();
 
-    SpecBase<TModel, TMetadata> IUnaryOperationSpec<TModel, TMetadata>.Operand => operand;
+    public SpecBase<TModel, TMetadata> Operand => operand;
 
     SpecBase<TModel> IUnaryOperationSpec<TModel>.Operand => operand;
+
+    SpecBase IUnaryOperationSpec.Operand => operand;
 }

--- a/Motiv/Not/NotPolicy.cs
+++ b/Motiv/Not/NotPolicy.cs
@@ -19,7 +19,9 @@ internal sealed class NotPolicy<TModel, TMetadata>(
     protected override PolicyResultBase<TMetadata> IsPolicySatisfiedBy(TModel model) =>
         operand.IsSatisfiedBy(model).Not();
 
-    public SpecBase<TModel, TMetadata> Operand => operand;
+    public PolicyBase<TModel, TMetadata> Operand => operand;
+
+    SpecBase<TModel, TMetadata> IUnaryOperationSpec<TModel, TMetadata>.Operand => operand;
 
     SpecBase<TModel> IUnaryOperationSpec<TModel>.Operand => operand;
 

--- a/Motiv/Not/NotSpec.cs
+++ b/Motiv/Not/NotSpec.cs
@@ -2,7 +2,10 @@ namespace Motiv.Not;
 
 internal sealed class NotSpec<TModel, TMetadata>(
     SpecBase<TModel, TMetadata> operand)
-    : SpecBase<TModel, TMetadata>, IUnaryOperationSpec<TModel, TMetadata>, IUnaryOperationSpec<TModel>
+    : SpecBase<TModel, TMetadata>,
+        IUnaryOperationSpec<TModel, TMetadata>,
+        IUnaryOperationSpec<TModel>,
+        IUnaryOperationSpec
 {
     public override IEnumerable<SpecBase> Underlying => operand.ToEnumerable();
 
@@ -16,7 +19,9 @@ internal sealed class NotSpec<TModel, TMetadata>(
     protected override BooleanResultBase<TMetadata> IsSpecSatisfiedBy(TModel model) =>
         operand.IsSatisfiedBy(model).Not();
 
-    SpecBase<TModel, TMetadata> IUnaryOperationSpec<TModel, TMetadata>.Operand => operand;
+    public SpecBase<TModel, TMetadata> Operand => operand;
 
     SpecBase<TModel> IUnaryOperationSpec<TModel>.Operand => operand;
+
+    SpecBase IUnaryOperationSpec.Operand => operand;
 }

--- a/Motiv/Or/OrSpec.cs
+++ b/Motiv/Or/OrSpec.cs
@@ -3,7 +3,10 @@ namespace Motiv.Or;
 internal sealed class OrSpec<TModel, TMetadata>(
     SpecBase<TModel, TMetadata> left,
     SpecBase<TModel, TMetadata> right)
-    : SpecBase<TModel, TMetadata>, IBinaryOperationSpec<TModel, TMetadata>, IBinaryOperationSpec<TModel>
+    : SpecBase<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel>,
+        IBinaryOperationSpec
 {
 
     public override IEnumerable<SpecBase> Underlying => left.ToEnumerable().Append(right);
@@ -30,5 +33,8 @@ internal sealed class OrSpec<TModel, TMetadata>(
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Right => Right;
 
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Left => Left;
-}
 
+    SpecBase IBinaryOperationSpec.Right => Right;
+
+    SpecBase IBinaryOperationSpec.Left => Left;
+}

--- a/Motiv/OrElse/OrElsePolicy.cs
+++ b/Motiv/OrElse/OrElsePolicy.cs
@@ -28,9 +28,13 @@ internal sealed class OrElsePolicy<TModel, TMetadata>(
         };
     }
 
-    public SpecBase<TModel, TMetadata> Left => left;
+    public PolicyBase<TModel, TMetadata> Left => left;
 
-    public SpecBase<TModel, TMetadata> Right => right;
+    public PolicyBase<TModel, TMetadata> Right => right;
+
+    SpecBase<TModel, TMetadata> IBinaryOperationSpec<TModel, TMetadata>.Left => left;
+
+    SpecBase<TModel, TMetadata> IBinaryOperationSpec<TModel, TMetadata>.Right => right;
 
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Right => Right;
 

--- a/Motiv/OrElse/OrElsePolicy.cs
+++ b/Motiv/OrElse/OrElsePolicy.cs
@@ -3,7 +3,10 @@ namespace Motiv.OrElse;
 internal sealed class OrElsePolicy<TModel, TMetadata>(
     PolicyBase<TModel, TMetadata> left,
     PolicyBase<TModel, TMetadata> right)
-    : PolicyBase<TModel, TMetadata>, IBinaryOperationSpec<TModel, TMetadata>, IBinaryOperationSpec<TModel>
+    : PolicyBase<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel>,
+        IBinaryOperationSpec
 {
 
     public override IEnumerable<SpecBase> Underlying => left.ToEnumerable().Append(right);
@@ -32,4 +35,8 @@ internal sealed class OrElsePolicy<TModel, TMetadata>(
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Right => Right;
 
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Left => Left;
+
+    SpecBase IBinaryOperationSpec.Right => Right;
+
+    SpecBase IBinaryOperationSpec.Left => Left;
 }

--- a/Motiv/OrElse/OrElseSpec.cs
+++ b/Motiv/OrElse/OrElseSpec.cs
@@ -3,7 +3,10 @@ namespace Motiv.OrElse;
 internal sealed class OrElseSpec<TModel, TMetadata>(
     SpecBase<TModel, TMetadata> left,
     SpecBase<TModel, TMetadata> right)
-    : SpecBase<TModel, TMetadata>, IBinaryOperationSpec<TModel, TMetadata>, IBinaryOperationSpec<TModel>
+    : SpecBase<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel>,
+        IBinaryOperationSpec
 {
 
     public override IEnumerable<SpecBase> Underlying => left.ToEnumerable().Append(right);
@@ -33,4 +36,8 @@ internal sealed class OrElseSpec<TModel, TMetadata>(
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Left => Left;
 
     public SpecBase<TModel, TMetadata> Right => right;
+
+    SpecBase IBinaryOperationSpec.Right => Right;
+
+    SpecBase IBinaryOperationSpec.Left => Left;
 }

--- a/Motiv/XOr/XOrSpec.cs
+++ b/Motiv/XOr/XOrSpec.cs
@@ -3,7 +3,10 @@ namespace Motiv.XOr;
 internal sealed class XOrSpec<TModel, TMetadata>(
     SpecBase<TModel, TMetadata> left,
     SpecBase<TModel, TMetadata> right)
-    : SpecBase<TModel, TMetadata>, IBinaryOperationSpec<TModel, TMetadata>, IBinaryOperationSpec<TModel>
+    : SpecBase<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel, TMetadata>,
+        IBinaryOperationSpec<TModel>,
+        IBinaryOperationSpec
 {
     public override IEnumerable<SpecBase> Underlying => left.ToEnumerable().Append(right);
 
@@ -28,4 +31,8 @@ internal sealed class XOrSpec<TModel, TMetadata>(
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Right => Right;
 
     SpecBase<TModel> IBinaryOperationSpec<TModel>.Left => Left;
+
+    SpecBase IBinaryOperationSpec.Right => Right;
+
+    SpecBase IBinaryOperationSpec.Left => Left;
 }


### PR DESCRIPTION
## Description
Expose genericless interfaces on boolean operation specs to assist with pattern matching in extension libraries

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Unit tested

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes