### PR TITLE
ci: prerelease-flag fix + bump actions off deprecated Node 20

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,11 +13,11 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           8.0.x
@@ -32,6 +32,6 @@ jobs:
     - name: List NuGet Packages
       run: Get-ChildItem -Path .\nupkgs\ -Recurse -Name
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         generate_release_notes: true
+        # Mark hyphenated SemVer tags (e.g. v8.0.0-rc.1, -beta, -alpha) as a GitHub
+        # prerelease; a plain tag like v8.0.0 stays a full "Latest" release.
+        prerelease: ${{ contains(github.ref_name, '-') }}
         files: |
           nupkgs/*.nupkg
           nupkgs/*.snupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout (full history for MinVer)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0   # MinVer needs full history + tags to derive the version
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
           8.0.x
@@ -45,7 +45,7 @@ jobs:
       run: dotnet nuget push "nupkgs/**/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         generate_release_notes: true
         # Mark hyphenated SemVer tags (e.g. v8.0.0-rc.1, -beta, -alpha) as a GitHub


### PR DESCRIPTION
Two small CI fixes surfaced by the `v8.0.0-rc.1` release dry run. Bundled together to avoid repeated merges through the locked `main`.

## 1. Mark prerelease GitHub Releases for hyphenated tags

```yaml
prerelease: ${{ contains(github.ref_name, '-') }}
```

`softprops/action-gh-release` doesn't infer prerelease status from the tag, so the `v8.0.0-rc.1` dry run created its GitHub Release as a normal "Latest" release. Now any hyphenated SemVer tag (`-rc.1`, `-beta`, `-alpha`) is flagged as a GitHub prerelease, while a plain `vX.Y.Z` stays a full release. NuGet is unaffected — it already derives prerelease status from the version suffix.

## 2. Bump actions off deprecated Node 20

The dry run warned that several actions target the deprecated Node 20 runtime (forced onto Node 24). Bumped each to its first Node 24 major:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-dotnet` | v4 | v5 |
| `softprops/action-gh-release` | v2 | v3 |
| `codecov/codecov-action` (CI) | v4.0.1 | v5 |

`CODECOV_TOKEN` is already supplied, so the codecov v5 bump needs no further config.

## Testing

- CI (`build`) runs on this PR and exercises the bumped `dotnet.yml` actions directly.
- `release.yml` changes will be exercised by the next tag push; the `prerelease` expression evaluates `true` for `v8.0.0-rc.2` and `false` for `v8.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
