### PR TITLE
docs: fix stale assertion notation in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -147,8 +147,8 @@ var isEven =
 var result = isEven.Evaluate(2);
 
 result.Satisfied;  // true
-result.Reason;     // "is even"
-result.Assertions; // ["is even"]
+result.Reason;     // "is even == true"
+result.Assertions; // ["is even == true"]
 result.Value;      // { Text: "even" }
 ```
 


### PR DESCRIPTION
## Summary

The landing-page example in `index.md` builds a metadata proposition named `"is even"`:

```csharp
Spec.Build((int n) => n % 2 == 0)
    .WhenTrue(new MyMetadata("even"))
    .WhenFalse(new MyMetadata("odd"))
    .Create("is even");
```

Because the metadata is a non-string object, the textual `Reason`/`Assertions` derive from the proposition name plus the `== true` / `== false` suffix. The inline comments showed the stale bare form (`"is even"`); this updates them to the correct `"is even == true"`.

No code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)